### PR TITLE
Enable -Wincomplete-uni-patterns

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 
 library
   default-language: Haskell2010
-  ghc-options:     -Wall -Werror -fno-ignore-asserts
+  ghc-options:     -Wall -Werror -Wincomplete-uni-patterns -Wincomplete-record-updates -fno-ignore-asserts
   hs-source-dirs:  src
   exposed-modules: Configuration
                  , EventLoop
@@ -58,7 +58,7 @@ executable hoff
   default-language: Haskell2010
   main-is:          Main.hs
   hs-source-dirs:   app
-  ghc-options:      -Wall -Werror
+  ghc-options:      -Wall -Werror -Wincomplete-uni-patterns -Wincomplete-record-updates
 
   build-depends: base         >= 4.8 && < 4.10
                , directory    >= 1.3 && < 1.4

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -12,6 +12,7 @@ module WebInterface (renderPage, viewIndex, viewProject) where
 
 import Control.Monad (forM_, unless, void)
 import Data.FileEmbed (embedStringFile)
+import Data.Maybe (fromJust)
 import Data.Text (Text)
 import Data.Text.Format.Params (Params)
 import Data.Text.Lazy (toStrict)
@@ -167,6 +168,6 @@ viewList :: (ProjectInfo -> PullRequestId -> PullRequest -> Html)
          -> Html
 viewList view info state prIds = forM_ prIds $ \ prId ->
   let
-    Just pr = Project.lookupPullRequest prId state
+    pr = fromJust $ Project.lookupPullRequest prId state
   in
     p $ view info prId pr

--- a/tests/ServerSpec.hs
+++ b/tests/ServerSpec.hs
@@ -118,8 +118,11 @@ withServer body = do
   let
     info = Project.ProjectInfo "deckard" "voight-kampff"
     tryEnqueue = Github.tryEnqueueEvent ghQueue
-    -- Fake the project state, always return the empty state.
-    getProjectState = const (Just (pure Project.emptyProjectState))
+    -- Fake the project state, always return the empty state,
+    -- if the project exists.
+    getProjectState forProject = if forProject == info
+      then Just $ pure Project.emptyProjectState
+      else Nothing
 
   -- Start the server on the test port, wait until it is ready to handle
   -- requests, and then run the body with access to the queue.


### PR DESCRIPTION
When I originally wrote Hoff I was not aware of this warning. It
prevents bugs, without it you can get match failures at runtime. It is
not included in -Wall though, it must be enabled explicitly.

Enable it in the library and binary but not in the tests; in the tests
it is sometimes useful to do let-bind a specific constructor. That keeps
the tests brief, and in tests it acts as an assertion and and binding in
one. A runtime error in the test suite is not an issue, that will just
make the tests fail.