### PR TITLE
Change approval syntax from "LGTM <sha>" to "@bot merge"

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -156,6 +156,10 @@ There are a few global options in the config file too:
    80 and 443) without having to run as root.
  * *TLS*: Can be used to make the server serve https instead of insecure http.
    See the [TLS guide](tls.md) for more details. Set to `null` to disable TLS.
+ * *Trigger.commentPrefix*: Specifies the prefix that makes Hoff interpret a
+   comment as a command directed at it. Setting this to the username of the bot
+   account makes for natural conversations on GitHub, but a different prefix
+   could be used too. In my case, I set it to `@hoffbot`.
 
 Finally, there is some Git config for the bot user, under the *user* key. *Name*
 and *email* are used for the Git committer metadata. *SshConfigFile* should

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -16,5 +16,8 @@
     "name": "CI Bot",
     "email": "cibot@example.com",
     "sshConfigFile": "/etc/hoff/ssh_config"
+  },
+  "trigger": {
+    "commentPrefix": "@hoffbot"
   }
 }

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -12,6 +12,7 @@ module Configuration
   Configuration (..),
   ProjectConfiguration (..),
   TlsConfiguration (..),
+  TriggerConfiguration (..),
   UserConfiguration (..),
   loadConfiguration
 )
@@ -32,6 +33,17 @@ data ProjectConfiguration = ProjectConfiguration
     checkout   :: FilePath, -- The path to a local checkout of the repository.
     reviewers  :: [Text],   -- List of GitHub usernames that are allowed to approve.
     stateFile  :: FilePath  -- The file where project state is stored.
+  }
+  deriving (Generic)
+
+data TriggerConfiguration = TriggerConfiguration
+  {
+    -- When a comment with this prefix is left on a PR, that triggers the
+    -- remainder of the comment to be interpreted as a directive at the bot.
+    -- Usually this would be the Github username of the bot (including @ but not
+    -- a space), e.g. "@hoffbot", and the comment "@hoffbot merge" would trigger
+    -- a merge. The prefix is case-insensitive.
+    commentPrefix :: Text
   }
   deriving (Generic)
 
@@ -66,6 +78,9 @@ data Configuration = Configuration
     -- The access token for the Github API, for leaving comments.
     accessToken :: Text,
 
+    -- Triggers that the bot may respond to.
+    trigger :: TriggerConfiguration,
+
     -- The port to run the webserver on.
     port :: Int,
 
@@ -80,6 +95,7 @@ data Configuration = Configuration
 instance FromJSON Configuration
 instance FromJSON ProjectConfiguration
 instance FromJSON TlsConfiguration
+instance FromJSON TriggerConfiguration
 instance FromJSON UserConfiguration
 
 -- Reads and parses the configuration. Returns Nothing if parsing failed, but

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -152,7 +152,7 @@ runLogicEventLoop appConfig userConfig projectConfig getNextEvent publish initia
       -- perform).
       logInfoN  $ Text.append "logic loop received event: " (Text.pack $ show event)
       logDebugN $ Text.append "state before: " (Text.pack $ show state0)
-      state1 <- runAll $ runAction $ Logic.handleEvent projectConfig event state0
+      state1 <- runAll $ runAction $ Logic.handleEvent (Config.trigger appConfig) projectConfig event state0
       state2 <- runAll $ runAction $ Logic.proceedUntilFixedPoint state1
       publish state2
       logDebugN $ Text.append "state after: " (Text.pack $ show state2)


### PR DESCRIPTION
Closes #2.

* Add a new configuration option, `trigger.commentPrefix` to choose a prefix that triggers the bot. It should be configurable because it is nice to set it to the username of the bot, so you can say “@bot merge”.
* The configuration is a nested object because the parser is just a derived `FromJSON`, and it is a bit nicer to pass just the necessary configuration to the application logic, and not the full config including secrets and unrelated values.
* Update the approval check to no longer care about the commit hash, but check for the prefix instead.
* Update tests and docs.