### PR TITLE
Add wrapper type for GitHub usernames

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -26,6 +26,7 @@ library
                  , Logic
                  , Project
                  , Server
+                 , Types
                  , WebInterface
 
   build-depends: aeson             >= 1.1  && < 1.2

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -24,15 +24,17 @@ import Data.Text (Text)
 import GHC.Generics
 import Prelude hiding (readFile)
 
+import Types (Username)
+
 data ProjectConfiguration = ProjectConfiguration
   {
-    owner      :: Text,     -- The GitHub user or organization who owns the repo.
-    repository :: Text,     -- The name of the repository.
-    branch     :: Text,     -- The branch to guard and integrate commits into.
-    testBranch :: Text,     -- The branch to force-push candidates to for testing.
-    checkout   :: FilePath, -- The path to a local checkout of the repository.
-    reviewers  :: [Text],   -- List of GitHub usernames that are allowed to approve.
-    stateFile  :: FilePath  -- The file where project state is stored.
+    owner      :: Text,       -- The GitHub user or organization who owns the repo.
+    repository :: Text,       -- The name of the repository.
+    branch     :: Text,       -- The branch to guard and integrate commits into.
+    testBranch :: Text,       -- The branch to force-push candidates to for testing.
+    checkout   :: FilePath,   -- The path to a local checkout of the repository.
+    reviewers  :: [Username], -- List of GitHub usernames that are allowed to approve.
+    stateFile  :: FilePath    -- The file where project state is stored.
   }
   deriving (Generic)
 

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -47,7 +47,7 @@ eventFromPullRequestPayload payload =
   let
     number = Github.number (payload :: PullRequestPayload) -- TODO: Use PullRequestId wrapper from beginning.
     title  = Github.title  (payload :: PullRequestPayload)
-    author = Github.author (payload :: PullRequestPayload) -- TODO: Wrapper type
+    author = Github.author (payload :: PullRequestPayload)
     branch = Github.branch (payload :: PullRequestPayload)
     sha    = Github.sha    (payload :: PullRequestPayload)
   in

--- a/src/Github.hs
+++ b/src/Github.hs
@@ -31,6 +31,7 @@ import Data.Aeson.Types (Parser, typeMismatch)
 import Data.Text (Text)
 import Git (Sha (..), Branch (..))
 import Project (ProjectInfo (..))
+import Types (Username)
 
 data PullRequestAction
   = Opened
@@ -54,22 +55,22 @@ data CommitStatus
 
 data PullRequestPayload = PullRequestPayload {
   action     :: PullRequestAction, -- Corresponds to "action".
-  owner      :: Text,   -- Corresponds to "pull_request.base.repo.owner.login".
-  repository :: Text,   -- Corresponds to "pull_request.base.repo.name".
-  number     :: Int,    -- Corresponds to "pull_request.number".
-  branch     :: Branch, -- Corresponds to "pull_request.head.ref".
-  sha        :: Sha,    -- Corresponds to "pull_request.head.sha".
-  title      :: Text,   -- Corresponds to "pull_request.title".
-  author     :: Text    -- Corresponds to "pull_request.user.login".
+  owner      :: Text,     -- Corresponds to "pull_request.base.repo.owner.login".
+  repository :: Text,     -- Corresponds to "pull_request.base.repo.name".
+  number     :: Int,      -- Corresponds to "pull_request.number".
+  branch     :: Branch,   -- Corresponds to "pull_request.head.ref".
+  sha        :: Sha,      -- Corresponds to "pull_request.head.sha".
+  title      :: Text,     -- Corresponds to "pull_request.title".
+  author     :: Username  -- Corresponds to "pull_request.user.login".
 } deriving (Eq, Show)
 
 data CommentPayload = CommentPayload {
   action     :: CommentAction, -- Corresponds to "action".
-  owner      :: Text, -- Corresponds to "repository.owner.login".
-  repository :: Text, -- Corresponds to "repository.name".
-  number     :: Int,  -- Corresponds to "issue.number".
-  author     :: Text, -- Corresponds to "sender.login".
-  body       :: Text  -- Corresponds to "comment.body".
+  owner      :: Text,     -- Corresponds to "repository.owner.login".
+  repository :: Text,     -- Corresponds to "repository.name".
+  number     :: Int,      -- Corresponds to "issue.number".
+  author     :: Username, -- Corresponds to "sender.login".
+  body       :: Text      -- Corresponds to "comment.body".
 } deriving (Eq, Show)
 
 data CommitStatusPayload = CommitStatusPayload {

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,0 +1,36 @@
+-- Hoff -- A gatekeeper for your commits
+-- Copyright 2020 The Hoff authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- A copy of the License has been included in the root of the repository.
+
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Types
+(
+  PullRequestId (..),
+  Username (..),
+)
+where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.String (IsString)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import qualified Data.Aeson as Aeson
+
+-- The name of a user on GitHub.
+newtype Username = Username Text deriving (Eq, Show, Generic, IsString)
+
+-- A pull request is identified by its number.
+newtype PullRequestId = PullRequestId Int deriving (Eq, Show, Generic)
+
+instance FromJSON PullRequestId
+instance FromJSON Username
+
+instance ToJSON PullRequestId where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+instance ToJSON Username where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -26,7 +26,8 @@ import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
 import qualified Data.Text.Format as Text
 
-import Project (ProjectInfo, ProjectState, PullRequest, PullRequestId (..))
+import Project (ProjectInfo, ProjectState, PullRequest)
+import Types (PullRequestId (..), Username (..))
 
 import qualified Project
 
@@ -147,7 +148,7 @@ viewPullRequestWithApproval :: ProjectInfo -> PullRequestId -> PullRequest -> Ht
 viewPullRequestWithApproval info prId pullRequest = do
   viewPullRequest info prId pullRequest
   case Project.approvedBy pullRequest of
-    Just username ->
+    Just (Username username) ->
       span ! class_ "review" $ do
         void "Approved by "
         -- TODO: Link to approval comment, not just username.

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -26,7 +26,8 @@ import EventLoop (convertGithubEvent)
 import Git (Branch (..), PushResult(..), Sha (..))
 import Github (CommentPayload, CommitStatusPayload, PullRequestPayload)
 import Logic hiding (runAction)
-import Project (ProjectState (ProjectState), PullRequest (PullRequest), PullRequestId (PullRequestId))
+import Project (ProjectState (ProjectState), PullRequest (PullRequest))
+import Types (PullRequestId (..), Username (..))
 
 import qualified Configuration as Config
 import qualified Github
@@ -52,12 +53,12 @@ testProjectConfig = Config.ProjectConfiguration {
 
 -- Functions to prepare certain test states.
 
-singlePullRequestState :: PullRequestId -> Branch -> Sha -> Text -> ProjectState
+singlePullRequestState :: PullRequestId -> Branch -> Sha -> Username -> ProjectState
 singlePullRequestState pr prBranch prSha prAuthor =
   let event = PullRequestOpened pr prBranch prSha "Untitled" prAuthor
   in  handleEventFlat event Project.emptyProjectState
 
-candidateState :: PullRequestId -> Branch -> Sha -> Text -> Sha -> ProjectState
+candidateState :: PullRequestId -> Branch -> Sha -> Username -> Sha -> ProjectState
 candidateState pr prBranch prSha prAuthor candidateSha =
   let state0 = singlePullRequestState pr prBranch prSha prAuthor
       state1 = Project.setIntegrationStatus pr (Project.Integrated candidateSha) state0


### PR DESCRIPTION
As a preparation for doing the auth check through the API (see also #3), instead of having a list of usernames in the configuration, we can improve the type safety of working with usernames with a wrapper type.

This does not change the schema, because the `{From,To}JSON` instance just renders the string itself.