### PR TITLE
Automatically ship apt packages

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,8 +10,11 @@ agent:
 blocks:
   - name: "Build"
     task:
+      secrets:
+        - name: "opsbot-github-key"
+
       jobs:
-        - name: "Build, test, package"
+        - name: "Build, test, package, ship"
           commands:
             - "checkout"
 
@@ -58,3 +61,6 @@ blocks:
 
             # Store the dependencies that Stack compiled for us.
             - "cache store stack-cache-$(checksum stack.yaml.lock)-$(checksum hoff.cabal) $HOME/.stack"
+
+            # Build a package and and ship it (ship only on a git tag build)
+            - "./package/build-and-ship-package-semaphore.sh"

--- a/package/build-and-ship-package-semaphore.sh
+++ b/package/build-and-ship-package-semaphore.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Entrypoint for building a package on Semaphore CI and shipping to our apt
+# file host. Only builds a package when the current build is a git tag.
+
+set -efuo pipefail
+
+if [[ "$SEMAPHORE" != "true" ]]; then
+    echo "Run this script from a Semaphore job"
+    exit 1
+fi
+
+# Get the version from the git history. Strip the first `v`
+# character as dpkg really wants versions to start with a digit.
+VERSION="$(git describe | cut -c2-)"
+export VERSION
+
+# Change to the directory of the current script so that we can
+# execute `build-package.sh` from the right location. VERSION
+# has already been set by the logic above.
+cd "$(dirname "$0")"
+fakeroot ./build-package.sh
+
+if [[ "$SEMAPHORE_GIT_REF_TYPE" != "tag" ]]; then
+    echo "Not on a tagged build. Skipping ship step."
+    exit 0
+fi
+
+PKGFILE="hoff_$VERSION-1.deb"
+FREIGHT_HOST="freight@archive.channable.com"
+
+scp "$PKGFILE" "$FREIGHT_HOST:/tmp/$PKGFILE"
+
+# Shellcheck false positive. We want the client side versions
+# of these variables, not the server side versions.
+# shellcheck disable=SC2087
+ssh -T "$FREIGHT_HOST" <<END
+freight add "/tmp/${PKGFILENAME} apt/xenial apt/bionic
+freight-cache
+rm /tmp/${PKGFILENAME}
+END


### PR DESCRIPTION
This PR automates shipping Hoff apt packages our apt package host.

We always attempt to build an apt package. That allows us to test changes to the packaging script on CI as well.

We only ship it when the rest of the build passes and we're on a git tag.

This makes some information about our DNS zone and a username that we use public. We decided that this is fine.

Note that Semaphore build logs are private and that we do not build pull requests from arbitrary sources. Therefore we don't run the risk of accidentally leaking these credentials through CI logs.