### PR TITLE
Host styles on separate URL

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -44,6 +44,7 @@ library
                , free              >= 4.12 && < 4.13
                , http-types        >= 0.9  && < 0.10
                , github            >= 0.16 && < 0.17
+               , memory            >= 0.14 && < 0.15
                , monad-logger      >= 0.3  && < 0.4
                , process           >= 1.2  && < 1.5
                , process-extras    >= 0.7  && < 0.8


### PR DESCRIPTION
Fixes https://github.com/channable/hoff/issues/12

Changes the generated HTML to include styles via a `<link>` tag instead of directly.

Serve the styles on a URL which contains the urlsafe base64 of the sha256 digest of the content of the stylesheet. This allows us to set aggressive caching headers without serving outdated styles.

I validated the changes here by running a local server and loading the web interface in both Chrome and Firefox. That works.

Chrome devtools shows that the styles are being cached as well.