### PR TITLE
Confirm receiving merge commands

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -19,15 +19,16 @@ where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.String (IsString)
 import Data.Text (Text)
+import Data.Text.Buildable (Buildable)
 import GHC.Generics (Generic)
 
 import qualified Data.Aeson as Aeson
 
 -- The name of a user on GitHub.
-newtype Username = Username Text deriving (Eq, Show, Generic, IsString)
+newtype Username = Username Text deriving (Eq, Show, Generic, IsString, Buildable)
 
 -- A pull request is identified by its number.
-newtype PullRequestId = PullRequestId Int deriving (Eq, Show, Generic)
+newtype PullRequestId = PullRequestId Int deriving (Eq, Ord, Show, Generic)
 
 instance FromJSON PullRequestId
 instance FromJSON Username


### PR DESCRIPTION
Fixes https://github.com/channable/hoff/issues/11

This makes Hoff post a comment that confirms it has received a valid merge command. This makes it more user-friendly to see when PRs have been added to the merge queue.