### PR TITLE
Tie approver role to GitHub push access

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -115,8 +115,7 @@ the config file (e.g. with `sudo --edit /etc/hoff/config.json`):
       "branch": "master",
       "testBranch": "testing",
       "checkout": "/var/lib/hoff/checkouts/ruuda/bogus",
-      "stateFile": "/var/lib/hoff/state/ruuda/bogus.json",
-      "reviewers": ["ruuda"]
+      "stateFile": "/var/lib/hoff/state/ruuda/bogus.json"
     }
 
 The meaning of the fields is as follows:

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -65,7 +65,9 @@ executable hoff
   build-depends: base         >= 4.8 && < 4.10
                , directory    >= 1.3 && < 1.4
                , hoff
-               , monad-logger >= 0.3 && < 0.4
+               , monad-logger >= 0.3  && < 0.4
+               , github       >= 0.16 && < 0.17
+               , text         >= 1.2  && < 1.3
 
 test-suite spec
   default-language: Haskell2010

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -5,8 +5,7 @@
     "branch": "master",
     "testBranch": "testing",
     "checkout": "/var/lib/hoff/checkouts/your-username/your-repo",
-    "stateFile": "/var/lib/hoff/state/your-username/your-repo.json",
-    "reviewers": ["your-github-username"]
+    "stateFile": "/var/lib/hoff/state/your-username/your-repo.json"
   }],
   "secret": "run 'head --bytes 32 /dev/urandom | base64' and paste output here",
   "accessToken": "paste a personal access token for a bot user here",

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -24,8 +24,6 @@ import Data.Text (Text)
 import GHC.Generics
 import Prelude hiding (readFile)
 
-import Types (Username)
-
 data ProjectConfiguration = ProjectConfiguration
   {
     owner      :: Text,       -- The GitHub user or organization who owns the repo.
@@ -33,7 +31,6 @@ data ProjectConfiguration = ProjectConfiguration
     branch     :: Text,       -- The branch to guard and integrate commits into.
     testBranch :: Text,       -- The branch to force-push candidates to for testing.
     checkout   :: FilePath,   -- The path to a local checkout of the repository.
-    reviewers  :: [Username], -- List of GitHub usernames that are allowed to approve.
     stateFile  :: FilePath    -- The file where project state is stored.
   }
   deriving (Generic)

--- a/src/GithubApi.hs
+++ b/src/GithubApi.hs
@@ -12,16 +12,17 @@
 -- run those operations against the real API.
 module GithubApi
 (
-  GithubOperationFree,
+  GithubOperationFree (..),
   GithubOperation,
   leaveComment,
+  hasPushAccess,
   runGithub,
 )
 where
 
 import Control.Monad.Free (Free, liftF)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Logger (MonadLogger, logInfoN, logWarnN)
+import Control.Monad.Logger (MonadLogger, logDebugN, logInfoN, logWarnN, logErrorN)
 import Data.Text (Text)
 
 import qualified Data.Text as Text
@@ -29,19 +30,32 @@ import qualified Data.Text as Text
 import qualified GitHub.Data.Id as Github3
 import qualified GitHub.Data.Name as Github3
 import qualified GitHub.Endpoints.Issues.Comments as Github3
+import qualified GitHub.Endpoints.Repos.Collaborators as Github3
 
-import Project (PullRequestId (..), ProjectInfo)
+import Project (ProjectInfo)
+import Types (PullRequestId (..), Username (..))
 
 import qualified Project
 
 data GithubOperationFree a
   = LeaveComment PullRequestId Text a
+  | HasPushAccess Username (Bool -> a)
   deriving (Functor)
 
 type GithubOperation = Free GithubOperationFree
 
 leaveComment :: PullRequestId -> Text -> GithubOperation ()
 leaveComment pr remoteBranch = liftF $ LeaveComment pr remoteBranch ()
+
+hasPushAccess :: Username -> GithubOperation Bool
+hasPushAccess username = liftF $ HasPushAccess username id
+
+isPermissionToPush :: Github3.CollaboratorPermission -> Bool
+isPermissionToPush perm = case perm of
+  Github3.CollaboratorPermissionAdmin -> True
+  Github3.CollaboratorPermissionWrite -> True
+  Github3.CollaboratorPermissionRead -> False
+  Github3.CollaboratorPermissionNone -> False
 
 runGithub
   :: MonadIO m
@@ -63,3 +77,30 @@ runGithub auth projectInfo operation =
         Left err -> logWarnN $ Text.append "Failed to comment: " $ Text.pack $ show err
         Right _ -> logInfoN $ Text.concat ["Posted comment on ", Text.pack $ show pr, ": ", body]
       pure cont
+
+    HasPushAccess (Username username) cont -> do
+      result <- liftIO $ Github3.collaboratorPermissionOn
+        (Just auth)
+        (Github3.N $ Project.owner projectInfo)
+        (Github3.N $ Project.repository projectInfo)
+        (Github3.N username)
+
+      case result of
+        Left err -> do
+          logErrorN
+            $ Text.append "Failed to retrive collaborator status: "
+            $ Text.pack $ show err
+          -- To err on the safe side, if the API call fails, we pretend nobody
+          -- has push access.
+          pure $ cont False
+
+        Right (Github3.CollaboratorWithPermission _user perm) -> do
+          logDebugN $ Text.concat
+            [ "User "
+            , username
+            , " has permission "
+            , Text.pack $ show perm
+            , " on "
+            , Text.pack $ show projectInfo
+            ]
+          pure $ cont $ isPermissionToPush perm

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,4 @@
 resolver: lts-9.0
-nix:
-  shell-file: shell.nix
-
-  # Make Stack look for "nixpks" in this repository,
-  # so it uses the pinned version.
-  path: ["."] 
+extra-deps:
+  - git: https://github.com/ruuda/github.git
+    commit: 32098416c898656abc029c91dd22c91a602e6027

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,21 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    cabal-file:
+      size: 6368
+      sha256: 4c6d5e1721fa2cf96251c31124f9b0c10002c81b107a9856e7b075583a48beb3
+    name: github
+    version: 0.16.0
+    git: https://github.com/ruuda/github.git
+    pantry-tree:
+      size: 13405
+      sha256: 04fb5c39aa05ea66699a0915e93b30009c7400f6720f6421f6eb7b0b08fc4b6f
+    commit: 32098416c898656abc029c91dd22c91a602e6027
+  original:
+    git: https://github.com/ruuda/github.git
+    commit: 32098416c898656abc029c91dd22c91a602e6027
 snapshots:
 - completed:
     size: 533451


### PR DESCRIPTION
Fixes #3.

* Rather than configuring a list of usernames whose comments can be interpreted as merge commands, check the GitHub API if the author of a comment has push access.
* This means less configuration to get things working, and less configuration that can go out of date.
  * As approver powers are effectively push access, so making approvers a strict superset of users with push access is not that useful anyway.
  * Users with push access can take all the steps that the bot would take manually, so making approvers a strict subset of users with push access is not that useful anyway.
  * Therefore it makes sense to treat push access as approver powers.
* Also, usernames being mutable is now no longer a big issue, as we check the permission directly when we receive the comment webhook. (There is a very small window between when the comment was left and when we do the check, but it requires an account with push access either way.)
* For the check, add a new command to the free monad, and one to the `GithubApi` free monad.
  * In production, we interpret that command to a real API call.
  * In tests, we use a fake interpreter that checks against a hard-coded list of usernames.
  * Parametrize the logic loop over the interpreters. This way, in `EventLoopSpec`, we can use the real IO interpreter for Git actions, and test with actual `git` calls, but still have a fake implementation for the GitHub API.
  * The endpoint we need was not exposed by the `github` library. I added it in a fork here https://github.com/ruuda/github/tree/collaborators-permission-016. If it works I will also open a pull request to upstream it.
* Refactor the `Spec` test suite a bit so we can verify the side effects, in addition to the final state. Use this to test that we don’t unnecessarily query the GitHub API.