### PR TITLE
Add OnFailure handler to systemd service

### DIFF
--- a/package/hoff.service
+++ b/package/hoff.service
@@ -4,6 +4,12 @@ After=network.target
 Requires=network.target
 AssertPathExists=/etc/hoff/config.json
 
+# Generic crash reporting. This makes systemd start the on-failure@hoff.service
+# unit when the process exits or fails to start. Comment this out if you do not
+# have a systemd unit with this name. See `package/on-failure@.service.example`
+# for an idea of what you can do with this.
+OnFailure=on-failure@%n
+
 [Service]
 User=hoff
 Group=hoff

--- a/package/on-failure@.service.example
+++ b/package/on-failure@.service.example
@@ -1,0 +1,20 @@
+# This is an example onfailure handler. See hoff.service for how
+# you can use this to wire up failure notifications when services
+# crash.
+
+[Unit]
+Description=Failure report for %i
+
+[Service]
+Type=oneshot
+
+# This can be a program which fetches the last loglines from the
+# journal and report this crash to a location you care about (e.g.
+# send chat messages, emails, or page people). It might have some
+# logic for inhibition, or be very stupid.
+#
+# Install in a file like `/etc/systemd/system/on-failure@.service`.
+# If you then run the command `systemctl start on-failure@foo`,
+# systemd will invoke `/usr/bin/yourfailurehandler foo`.  `%i`
+# will be expanded to whatever you put after the @.
+ExecStart=/usr/bin/yourfailurehandler %i


### PR DESCRIPTION
Make systemd start our default `OnFailure` handler when there are problems with the process. Also add an example of what such a unit file could look like so others know what the purpose of this directive is.