### PR TITLE
Use foldFree to implement the free monad interpreters

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -86,10 +86,11 @@ test-suite spec
                , filepath   >= 1.4  && < 1.5
                , free       >= 4.12 && < 4.13
                , hoff
-               , hspec      >= 2.4  && < 2.5
-               , hspec-core >= 2.4  && < 2.5
-               , text       >= 1.2  && < 1.3
-               , uuid       >= 1.3  && < 1.4
+               , hspec        >= 2.4  && < 2.5
+               , hspec-core   >= 2.4  && < 2.5
+               , text         >= 1.2  && < 1.3
+               , transformers >= 0.5  && < 0.6
+               , uuid         >= 1.3  && < 1.4
 
 test-suite end-to-end
   default-language: Haskell2010

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -5,10 +5,12 @@
 -- you may not use this file except in compliance with the License.
 -- A copy of the License has been included in the root of the repository.
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
-import Control.Monad.Free (Free (..))
+import Control.Monad.Free (foldFree)
+import Control.Monad.Trans.Writer (Writer, tell, runWriter)
 import Data.Aeson (decode, encode)
 import Data.ByteString.Lazy (readFile)
 import Data.Foldable (foldlM)
@@ -67,26 +69,30 @@ data ActionFlat
 -- together with a list of all actions that would have been performed. Some
 -- actions require input from the outside world. Simulating these actions will
 -- return the pushResult and rebaseResult passed in here.
-runActionWithInit :: Maybe Sha -> PushResult -> [ActionFlat] -> Action a -> (a, [ActionFlat])
-runActionWithInit integrateResult pushResult actions action =
+runActionWithInit :: Maybe Sha -> PushResult -> Action a -> Writer [ActionFlat] a
+runActionWithInit integrateResult pushResult =
   let
     -- In the tests, only "deckard" is a reviewer.
     isReviewer username = username == "deckard"
-    prepend cont act =
-      let (result, acts') = runActionWithInit integrateResult pushResult actions cont
-      in  (result, act : acts')
   in
-    case action of
-      Pure result                          -> (result, [])
-      Free (TryIntegrate msg candi h)      -> prepend (h integrateResult) $ ATryIntegrate msg candi
-      Free (TryPromote prBranch headSha h) -> prepend (h pushResult) $ ATryPromote prBranch headSha
-      Free (LeaveComment pr body x)        -> prepend x $ ALeaveComment pr body
-      Free (IsReviewer username h)         -> prepend (h $ isReviewer username) $ AIsReviewer username
+    foldFree $ \case
+      TryIntegrate msg candi h -> do
+        tell [ATryIntegrate msg candi]
+        pure $ h integrateResult
+      TryPromote prBranch headSha h -> do
+        tell [ATryPromote prBranch headSha]
+        pure $ h pushResult
+      LeaveComment pr body x -> do
+        tell [ALeaveComment pr body]
+        pure x
+      IsReviewer username h -> do
+        tell [AIsReviewer username]
+        pure $ h $ isReviewer username
 
 -- Simulates running the action. Pretends that integration always conflicts.
 -- Pretends that pushing is always successful.
 runAction :: Action a -> (a, [ActionFlat])
-runAction = runActionWithInit Nothing PushOk []
+runAction = runWriter . runActionWithInit Nothing PushOk
 
 -- Handle an event and simulate its side effects, then ignore the side effects
 -- and return the new state.
@@ -101,9 +107,13 @@ handleEventsFlat events state = runAction
 
 -- Proceed with a state until a fixed point, simulate and collect the side
 -- effects.
-proceedUntilFixedPointFlat :: Maybe Sha -> PushResult -> ProjectState -> (ProjectState, [ActionFlat])
+proceedUntilFixedPointFlat
+  :: Maybe Sha
+  -> PushResult
+  -> ProjectState
+  -> (ProjectState, [ActionFlat])
 proceedUntilFixedPointFlat integrateResult pushResult state =
-  runActionWithInit integrateResult pushResult [] $ proceedUntilFixedPoint state
+  runWriter $ runActionWithInit integrateResult pushResult $ proceedUntilFixedPoint state
 
 main :: IO ()
 main = hspec $ do


### PR DESCRIPTION
As suggested earlier by @rightfold, we can simplify the matching with `foldFree`. This is indeed a nice cleanup!

In the tests, when using `foldFree` we need a monad instance, but fortunately `Monoid a => Monad ((,) a)` provides one, where we can instantiate `a = [ActionFlat]`. That allows removing even more boilerplate! The downside is that in order to use the instance, we need to swap the elements in the returned tuple. Not a big deal, but it clutters the diff.

This pull request can be reviewed commit by commit. The first two commits are the important ones, the last two are cosmetic.