### PR TITLE
WebInterface: Use Source Sans Pro font from Google Fonts

### DIFF
--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -58,6 +58,12 @@ stylesheetUrlDigest = showAs Base64URLUnpadded stylesheetDigest
 stylesheetBase64Digest :: Text
 stylesheetBase64Digest = showAs Base64 stylesheetDigest
 
+-- URL to the Google Fonts stylesheet. The family parameter is a pipe-separated
+-- list of font families. The display parameter corresponds to the CSS
+-- font-display property.
+googlefontsUrl :: Text
+googlefontsUrl = "https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap"
+
 -- URL to host the stylesheet at. Including a digest in this URL means we
 -- can set the @Cache-Control: immutable@ header to facilitate caching.
 -- That's both less wasteful and easier to implement than 304 responses
@@ -74,6 +80,7 @@ renderPage pageTitle bodyHtml = renderHtml $ docTypeHtml $ do
     meta ! name "viewport" ! content "width=device-width, initial-scale=1"
     meta ! name "robots" ! content "noindex, nofollow"
     title $ toHtml pageTitle
+    link ! rel "stylesheet" ! href (toValue googlefontsUrl)
     link ! rel "stylesheet" ! href (toValue stylesheetUrl) ! integrity (toValue $ "sha256-" <> stylesheetBase64Digest)
   body $
     div ! id "content" $


### PR DESCRIPTION
Not all users have this font installed. If they do not, then it will be
downloaded automatically from Google’s font CDN.