### PR TITLE
Avoid falsely acknowledging pull requests

### DIFF
--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -269,6 +269,16 @@ main = hspec $ do
         , ALeaveComment (PullRequestId 3) "Pull request approved by @deckard, waiting for rebase behind 2 pull requests."
         ]
 
+    it "ignores comments on unknown pull requests" $ do
+      let
+        -- We comment on PR #1, but the project is empty, so this comment should
+        -- be dropped on the floor.
+        event = CommentAdded (PullRequestId 1) "deckard" "@bot merge"
+        (state, actions) = handleEventFlat event Project.emptyProjectState
+      -- We expect no changes to the state, and in particular, no side effects.
+      state `shouldBe` Project.emptyProjectState
+      actions `shouldBe` []
+
   describe "Logic.proceedUntilFixedPoint" $ do
 
     it "finds a new candidate" $ do


### PR DESCRIPTION
Fixes #35. If we get a comment on an unknown pull request, we should not acknowledge it. (It would be nice if the pull request was not unknown in the first place, but that is a separate issue.)

* Add a test that reproduces the bug. It fails:

![test-fail](https://user-images.githubusercontent.com/506953/72605387-f32e8080-391c-11ea-80a8-5677e78368e4.png)

* Fix the bug by only interpreting comments on known pull requests. This fixes the test.
* Move the actual handling into a function to avoid rightward drift / explosion of if-then-else.