### PR TITLE
Fix queue position message

### DIFF
--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -147,10 +147,9 @@ runLogicEventLoop triggerConfig projectConfig runGit runGithub getNextEvent publ
       logInfoN  $ Text.append "logic loop received event: " (Text.pack $ show event)
       logDebugN $ Text.append "state before: " (Text.pack $ show state0)
       state1 <- runAll $ runAction $ Logic.handleEvent triggerConfig event state0
-      state2 <- runAll $ runAction $ Logic.proceedUntilFixedPoint state1
-      publish state2
-      logDebugN $ Text.append "state after: " (Text.pack $ show state2)
-      runLoop state2
+      publish state1
+      logDebugN $ Text.append "state after: " (Text.pack $ show state1)
+      runLoop state1
 
     runLoop state = do
       -- Before anything, clone the repository if there is no clone.


### PR DESCRIPTION
There was a bug in the queue position reporting: in filtering, the logic did not distinguish between pull requests that are already in progress, and pull requests that still need to be rebased. The former kind are always ahead in the queue, even if the pull request number if higher.

I added a regression test for that, and a fix, but then I ran into some issues with the test suite, so this fix grew a bit larger than I intended, but I hope it is still manageable.

When handling events, there are two phases:

* We handle the event itself, which produces a new state.
* We iterate `proceed` on that state until we reach a fixed point. That is, `proceed` checks if there is any action it can take, and if there is it takes it. So when we reach a fixed point, there is nothing left to do.

In the production event loop, these are interleaved. After handling an event, we proceed until a fixed point, and only then do we handle the next event. But in the tests, we were only testing `handleEvent`, without advancing to a fixed point. Especially for `handleEvents` that was a problem, because normally we only apply events to states that are a fixed point of `proceed`, and when we apply it to a different state, it can observe invalid combinations, such as a pull request that has been integrated but where the build status is not yet pending. Fix this by renaming `handleEvent` to `handleEventInternal`, and adding a new `handleEvent` that calls `handleEventInternal` and then proceeds until a fixed point.

There are some things that could be improved; perhaps we should not have this split at all, and change the types to make invalid states unrepresentable. That would move more logic into event handling, but it also means that you never have these intermediate states that we don't expect to apply events to. But let's not do that right now.
