### PR TITLE
Bump LTS to 14.21

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -50,7 +50,7 @@ blocks:
             # library is tagged as "license other" on Hackage, but the license
             # appears to be ISC, so whitelist it too. See also [1].
             # [1]: https://hackage.haskell.org/package/unexceptionalio-0.3.0/src/COPYING.
-            - "! stack ls dependencies --license | egrep -v 'Apache-2|BSD2|BSD3|MIT|PublicDomain|MPL-2.0|unexceptionalio'"
+            - "! stack ls dependencies --license | egrep -v 'Apache-2|BSD-?2|BSD-?3|MIT|ISC|PublicDomain|MPL-2.0|unexceptionalio'"
 
             # Check shell scripts for issues.
             - "shellcheck package/*.sh package/deb-postinst"

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -29,32 +29,32 @@ library
                  , Types
                  , WebInterface
 
-  build-depends: aeson             >= 1.1  && < 1.2
-               , aeson-pretty      >= 0.7  && < 0.9
-               , base              >= 4.8  && < 4.10
-               , base16-bytestring >= 0.1  && < 0.2
-               , blaze-html        >= 0.9  && < 0.10
-               , blaze-markup      >= 0.8  && < 0.9
-               , bytestring        >= 0.10 && < 0.11
-               , containers        >= 0.5  && < 0.6
-               , cryptonite        >= 0.23 && < 0.24
-               , directory         >= 1.3  && < 1.4
-               , file-embed        >= 0.0  && < 0.1
-               , filepath          >= 1.4  && < 1.5
-               , free              >= 4.12 && < 4.13
-               , http-types        >= 0.9  && < 0.10
-               , github            >= 0.16 && < 0.17
-               , memory            >= 0.14 && < 0.15
-               , monad-logger      >= 0.3  && < 0.4
-               , process           >= 1.2  && < 1.5
-               , process-extras    >= 0.7  && < 0.8
-               , scotty            >= 0.11 && < 0.12
-               , stm               >= 2.4  && < 2.5
-               , text              >= 1.2  && < 1.3
-               , text-format       >= 0.3  && < 0.4
-               , wai               >= 3.2  && < 3.3
-               , warp              >= 3.2  && < 3.3
-               , warp-tls          >= 3.2  && < 3.3
+  build-depends: aeson
+               , aeson-pretty
+               , base
+               , base16-bytestring
+               , blaze-html
+               , blaze-markup
+               , bytestring
+               , containers
+               , cryptonite
+               , directory
+               , file-embed
+               , filepath
+               , free
+               , http-types
+               , github
+               , memory
+               , monad-logger
+               , process
+               , process-extras
+               , scotty
+               , stm
+               , text
+               , text-format
+               , wai
+               , warp
+               , warp-tls
 
 executable hoff
   default-language: Haskell2010
@@ -62,12 +62,12 @@ executable hoff
   hs-source-dirs:   app
   ghc-options:      -Wall -Werror -Wincomplete-uni-patterns -Wincomplete-record-updates
 
-  build-depends: base         >= 4.8 && < 4.10
-               , directory    >= 1.3 && < 1.4
+  build-depends: base
+               , directory
                , hoff
-               , monad-logger >= 0.3  && < 0.4
-               , github       >= 0.16 && < 0.17
-               , text         >= 1.2  && < 1.3
+               , monad-logger
+               , github
+               , text
 
 test-suite spec
   default-language: Haskell2010
@@ -76,21 +76,21 @@ test-suite spec
   hs-source-dirs: tests
   ghc-options:    -Wall -Werror
 
-  build-depends: aeson      >= 1.1  && < 1.2
-               , base       >= 4.8  && < 4.10
-               , bytestring >= 0.10 && < 0.11
-               , containers >= 0.5  && < 0.6
+  build-depends: aeson
+               , base
+               , bytestring
+               , containers
                -- TODO: Use the new function that really deletes directories,
                -- instead of rolling my own.
-               , directory  >= 1.3  && < 1.4
-               , filepath   >= 1.4  && < 1.5
-               , free       >= 4.12 && < 4.13
+               , directory
+               , filepath
+               , free
                , hoff
-               , hspec        >= 2.4  && < 2.5
-               , hspec-core   >= 2.4  && < 2.5
-               , text         >= 1.2  && < 1.3
-               , transformers >= 0.5  && < 0.6
-               , uuid         >= 1.3  && < 1.4
+               , hspec
+               , hspec-core
+               , text
+               , transformers
+               , uuid
 
 test-suite end-to-end
   default-language: Haskell2010
@@ -100,21 +100,21 @@ test-suite end-to-end
   hs-source-dirs: tests
   ghc-options:    -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
 
-  build-depends: async        >= 2.1  && < 2.2
-               , base         >= 4.8  && < 4.10
-               , bytestring   >= 0.10 && < 0.11
-               , cryptonite   >= 0.23 && < 0.24
-               , filepath     >= 1.4  && < 1.5
+  build-depends: async
+               , base
+               , bytestring
+               , cryptonite
+               , filepath
                -- TODO: Use the new function that really deletes directories,
                -- instead of rolling my own.
-               , directory    >= 1.3  && < 1.4
+               , directory
                , hoff
-               , http-conduit >= 2.2  && < 2.3
-               , hspec        >= 2.4  && < 2.5
-               , hspec-core   >= 2.4  && < 2.5
-               , http-types   >= 0.9  && < 0.10
-               , monad-logger >= 0.3  && < 0.4
-               , random       >= 1.1  && < 1.2
-               , stm          >= 2.4  && < 2.5
-               , text         >= 1.2  && < 1.3
-               , uuid         >= 1.3  && < 1.4
+               , http-conduit
+               , hspec
+               , hspec-core
+               , http-types
+               , monad-logger
+               , random
+               , stm
+               , text
+               , uuid

--- a/src/Github.hs
+++ b/src/Github.hs
@@ -29,6 +29,8 @@ import Control.Monad.STM (atomically)
 import Data.Aeson (FromJSON (parseJSON), Object, Value (Object, String), (.:))
 import Data.Aeson.Types (Parser, typeMismatch)
 import Data.Text (Text)
+import GHC.Natural (Natural)
+
 import Git (Sha (..), Branch (..))
 import Project (ProjectInfo (..))
 import Types (Username)
@@ -174,7 +176,7 @@ eventProjectInfo event =
 type EventQueue = TBQueue WebhookEvent
 
 -- Creates a new event queue with the given maximum capacity.
-newEventQueue :: Int -> IO EventQueue
+newEventQueue :: Natural -> IO EventQueue
 newEventQueue capacity = atomically $ newTBQueue capacity
 
 -- Enqueues the event if the queue is not full. Returns whether the event has

--- a/src/GithubApi.hs
+++ b/src/GithubApi.hs
@@ -27,10 +27,10 @@ import Data.Text (Text)
 
 import qualified Data.Text as Text
 
-import qualified GitHub.Data.Id as Github3
 import qualified GitHub.Data.Name as Github3
 import qualified GitHub.Endpoints.Issues.Comments as Github3
 import qualified GitHub.Endpoints.Repos.Collaborators as Github3
+import qualified GitHub.Request as Github3
 
 import Project (ProjectInfo)
 import Types (PullRequestId (..), Username (..))
@@ -67,11 +67,10 @@ runGithub
 runGithub auth projectInfo operation =
   case operation of
     LeaveComment (PullRequestId pr) body cont -> do
-      result <- liftIO $ Github3.createComment
-        auth
+      result <- liftIO $ Github3.github auth $ Github3.createCommentR
         (Github3.N $ Project.owner projectInfo)
         (Github3.N $ Project.repository projectInfo)
-        (Github3.Id pr)
+        (Github3.IssueNumber pr)
         body
       case result of
         Left err -> logWarnN $ Text.append "Failed to comment: " $ Text.pack $ show err
@@ -79,8 +78,7 @@ runGithub auth projectInfo operation =
       pure cont
 
     HasPushAccess (Username username) cont -> do
-      result <- liftIO $ Github3.collaboratorPermissionOn
-        (Just auth)
+      result <- liftIO $ Github3.github auth $ Github3.collaboratorPermissionOnR
         (Github3.N $ Project.owner projectInfo)
         (Github3.N $ Project.repository projectInfo)
         (Github3.N username)

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -42,6 +42,7 @@ import Data.Text (Text)
 import Data.Text.Format.Params (Params)
 import Data.Text.Lazy (toStrict)
 import Data.Functor.Sum (Sum (InL, InR))
+import GHC.Natural (Natural)
 
 import qualified Data.Text as Text
 import qualified Data.Text.Format as Text
@@ -164,7 +165,7 @@ type EventQueue = TBQueue (Maybe Event)
 type StateVar = TMVar ProjectState
 
 -- Creates a new event queue with the given maximum capacity.
-newEventQueue :: Int -> IO EventQueue
+newEventQueue :: Natural -> IO EventQueue
 newEventQueue capacity = atomically $ newTBQueue capacity
 
 -- Enqueues an event, blocks if the queue is full.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,7 @@
-resolver: lts-9.0
+resolver: lts-14.21
 extra-deps:
+  # Custom fork for now because we added an endpoint.
   - git: https://github.com/ruuda/github.git
-    commit: 32098416c898656abc029c91dd22c91a602e6027
+    commit: 8bcd2a957bfc074fc537798524d8e6e3c27efdd6
+  # Dependency of the "github" package.
+  - binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,21 +6,28 @@
 packages:
 - completed:
     cabal-file:
-      size: 6368
-      sha256: 4c6d5e1721fa2cf96251c31124f9b0c10002c81b107a9856e7b075583a48beb3
+      size: 6955
+      sha256: dffa9964449fee9aefdbef8d7c2c7b3aa560cf578f9fd2923ae48fc75dcf7090
     name: github
-    version: 0.16.0
+    version: '0.24'
     git: https://github.com/ruuda/github.git
     pantry-tree:
-      size: 13405
-      sha256: 04fb5c39aa05ea66699a0915e93b30009c7400f6720f6421f6eb7b0b08fc4b6f
-    commit: 32098416c898656abc029c91dd22c91a602e6027
+      size: 15769
+      sha256: cc4a674fd3691b09a46bd923ba3118f8c5edf01b87c5f7657723ebffc313b7c5
+    commit: 8bcd2a957bfc074fc537798524d8e6e3c27efdd6
   original:
     git: https://github.com/ruuda/github.git
-    commit: 32098416c898656abc029c91dd22c91a602e6027
+    commit: 8bcd2a957bfc074fc537798524d8e6e3c27efdd6
+- completed:
+    hackage: binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613
+    pantry-tree:
+      size: 1035
+      sha256: 938ffc6990cac12681c657f7afa93737eecf335e6f0212d8c0b7c1ea3e0f40f4
+  original:
+    hackage: binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613
 snapshots:
 - completed:
-    size: 533451
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/9/0.yaml
-    sha256: 27f29b231b39ea68e967a7a4346b2693a49d77c50f41fc0c276e11189a538da7
-  original: lts-9.0
+    size: 524162
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/21.yaml
+    sha256: 9a55dd75853718f2bbbe951872b36a3b7802fcd71796e0f25b8664f24e34c666
+  original: lts-14.21


### PR DESCRIPTION
Upgrade to Stackage LTS 14.21, the latest LTS at the time of writing.
    
Two breaking changes in dependencies:
    
  * The `github` package no longer exposes IO operations of its requests, only the variants with `R` suffix that build the request. We then have to use the `github auth` function to perform the request in IO.
    
  * `STM.newTBQueue` now takes a `Natural` instead of an `Int` as queue size.
    
We have to add one dependency of the `github` package as an extra-dep. After fixing all of this, everything compiles, and the tests still pass.

I also dropped the version constraints from the Cabal file; it is only annoying to have to update them all the time, and the Stackage snapshot pins the versions anyway.
