### PR TITLE
Don't lose approval status after losing push race

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -37,7 +37,7 @@ import Control.Exception (assert)
 import Control.Monad (mfilter, when, void)
 import Control.Monad.Free (Free (..), foldFree, liftF, hoistFree)
 import Control.Monad.STM (atomically)
-import Data.Maybe (fromJust, fromMaybe, isJust, maybe)
+import Data.Maybe (fromJust, fromMaybe, isJust)
 import Data.Text (Text)
 import Data.Text.Format.Params (Params)
 import Data.Text.Lazy (toStrict)
@@ -228,17 +228,21 @@ handlePullRequestCommitChanged pr newSha state =
     closedState = handlePullRequestClosed pr state
     update pullRequest =
       let
-        oldSha   = Pr.sha pullRequest
-        branch   = Pr.branch pullRequest
-        title    = Pr.title pullRequest
-        author   = Pr.author pullRequest
-        newState = closedState >>= handlePullRequestOpened pr branch newSha title author
+        branch = Pr.branch pullRequest
+        title  = Pr.title pullRequest
+        author = Pr.author pullRequest
       in
-        -- If the change notification was a false positive, ignore it.
-        if oldSha == newSha then return state else newState
+        closedState >>= handlePullRequestOpened pr branch newSha title author
   in
-    -- If the pull request was not present in the first place, do nothing.
-    maybe (return state) update $ Pr.lookupPullRequest pr state
+    case Pr.lookupPullRequest pr state of
+      -- If the change notification was a false positive, ignore it.
+      Just pullRequest | Pr.sha pullRequest == newSha -> pure state
+      -- If the new commit hash is one that we pushed ourselves, ignore the
+      -- change too, we don't want to lose the approval status.
+      Just pullRequest | newSha `Pr.wasIntegrationAttemptFor` pullRequest -> pure state
+      Just pullRequest -> update pullRequest
+      -- If the pull request was not present in the first place, do nothing.
+      Nothing -> pure state
 
 handlePullRequestClosed :: PullRequestId -> ProjectState -> Action ProjectState
 handlePullRequestClosed pr state = return $ Pr.deletePullRequest pr state {


### PR DESCRIPTION
Fixes #38.

* When we receive a webhook about the commit of a pull request having changed, we clear approval, because the new commit is not the thing that was approved.
* However, when that webhook was caused by push that we initiated ourselves, that should not lose approval; we should just ignore it, and that will automatically cause us to try again.
* In order to know which webhooks to ignore, track all historic integration candidates (the result of a rebase-merge). In the best case there is only one, but if we could not push to master, then we need to start over, and in that case multiple integration candidates can accumulate.

This does add a new field, so the schema changes. We can no longer rely on the derived `fromJSON` instance for `PullRequest`, if we want to have a backwards-compatible decode-upgrade. <del>I will still add that later.</del><ins>I added a custom instance now</ins>.

CC @rkrzr you may be interested in this too.