### PR TITLE
Add read-only mode

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -64,9 +64,10 @@ executable hoff
 
   build-depends: base
                , directory
+               , github
                , hoff
                , monad-logger
-               , github
+               , optparse-applicative
                , text
 
 test-suite spec

--- a/src/GithubApi.hs
+++ b/src/GithubApi.hs
@@ -14,9 +14,12 @@ module GithubApi
 (
   GithubOperationFree (..),
   GithubOperation,
-  leaveComment,
+  PullRequestState (..),
+  getPullRequestState,
   hasPushAccess,
+  leaveComment,
   runGithub,
+  runGithubReadOnly,
 )
 where
 
@@ -28,7 +31,9 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 
 import qualified GitHub.Data.Name as Github3
+import qualified GitHub.Data.Options as Github3
 import qualified GitHub.Endpoints.Issues.Comments as Github3
+import qualified GitHub.Endpoints.PullRequests as Github3
 import qualified GitHub.Endpoints.Repos.Collaborators as Github3
 import qualified GitHub.Request as Github3
 
@@ -37,9 +42,15 @@ import Types (PullRequestId (..), Username (..))
 
 import qualified Project
 
+data PullRequestState
+  = StateOpen
+  | StateClosed
+  | StateUnknown -- When checking GitHub fails.
+
 data GithubOperationFree a
   = LeaveComment PullRequestId Text a
   | HasPushAccess Username (Bool -> a)
+  | GetPullRequestState PullRequestId (PullRequestState -> a)
   deriving (Functor)
 
 type GithubOperation = Free GithubOperationFree
@@ -49,6 +60,9 @@ leaveComment pr remoteBranch = liftF $ LeaveComment pr remoteBranch ()
 
 hasPushAccess :: Username -> GithubOperation Bool
 hasPushAccess username = liftF $ HasPushAccess username id
+
+getPullRequestState :: PullRequestId -> GithubOperation PullRequestState
+getPullRequestState pr = liftF $ GetPullRequestState pr id
 
 isPermissionToPush :: Github3.CollaboratorPermission -> Bool
 isPermissionToPush perm = case perm of
@@ -102,3 +116,40 @@ runGithub auth projectInfo operation =
             , Text.pack $ show projectInfo
             ]
           pure $ cont $ isPermissionToPush perm
+
+    GetPullRequestState (PullRequestId pr) cont -> do
+      result <- liftIO $ Github3.github auth $ Github3.pullRequestR
+        (Github3.N $ Project.owner projectInfo)
+        (Github3.N $ Project.repository projectInfo)
+        (Github3.IssueNumber pr)
+      case result of
+        Left err -> do
+          logWarnN $ Text.append "Failed to retrieve pull request: " $ Text.pack $ show err
+          pure $ cont StateUnknown
+        Right details -> case Github3.pullRequestState details of
+          Github3.StateOpen -> pure $ cont StateOpen
+          Github3.StateClosed -> pure $ cont StateClosed
+
+-- Like runGithub, but does not execute operations that have side effects, in
+-- the sense of being observable by Github users. We will still make requests
+-- against the read-only endpoints of the API. This is useful for local testing.
+runGithubReadOnly
+  :: MonadIO m
+  => MonadLogger m
+  => Github3.Auth
+  -> ProjectInfo
+  -> GithubOperationFree a
+  -> m a
+runGithubReadOnly auth projectInfo operation =
+  let
+    unsafeResult = runGithub auth projectInfo operation
+  in
+    case operation of
+      -- These operations are read-only, we can run them for real.
+      HasPushAccess {} -> unsafeResult
+      GetPullRequestState {} -> unsafeResult
+
+      -- These operations have side effects, we fake them.
+      LeaveComment pr body cont -> do
+        logInfoN $ Text.concat ["Would have posted comment on ", Text.pack $ show pr, ": ", body]
+        pure cont

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -196,6 +196,12 @@ fakeRunGithub :: Monad m => GithubOperationFree a -> m a
 fakeRunGithub action = case action of
   GithubApi.LeaveComment _pr _body cont -> pure cont
   GithubApi.HasPushAccess username cont -> pure $ cont (username `elem` ["rachael", "deckard"])
+  GithubApi.GetPullRequestState (PullRequestId pr) cont -> case pr of
+    -- In these tests, PR 17 is always closed, PR 19 always fails, and any other
+    -- PR is always open, when we query GitHub.
+    17 -> pure $ cont GithubApi.StateClosed
+    19 -> pure $ cont GithubApi.StateUnknown
+    _  -> pure $ cont GithubApi.StateOpen
 
 -- Runs the main loop in a separate thread, and feeds it the given events.
 runMainEventLoop


### PR DESCRIPTION
I started working on #10, but in order to test this locally, I need to fill in a valid GitHub API key. But I don’t want my local Hoff to start leaving comments, or pushing to GitHub. So as a safety precaution, add a read-only mode.

* Add a command-line switch, `--read-only` to enable read-only mode.
* Add interpreters for the Git and GitHub free monads that only log dangerous operations, but do not execute them. The reads get forwarded to the real interpreters.

Now we can run Hoff locally with `--read-only`, and it will not push or comment on GitHub, but it can still fetch, check collaborator status, etc.

Also part of this PR, in preparation for #10, add an operation to get the open/closed state of a pull request.