### PR TITLE
Synchronize with GitHub at startup

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -155,6 +155,12 @@ runMain options = do
     zipped = zip4 (Config.projects config) projectQueues stateVars projectStates
     tuples = map (\(cfg, (_, a), (_, b), (_, c)) -> (cfg, a, b, c)) zipped
   forM_ tuples $ \ (projectConfig, projectQueue, stateVar, projectState) -> do
+    -- At startup, enqueue a synchronize event. This will bring the state in
+    -- sync with the current state of GitHub, accounting for any webhooks that
+    -- we missed while not running, or just to fill the state initially after
+    -- setting up a new project.
+    liftIO $ Logic.enqueueEvent projectQueue Logic.Synchronize
+
     let
       -- When the event loop publishes the current project state, save it to
       -- the configured file, and make the new state available to the

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -20,6 +20,7 @@ library
   hs-source-dirs:  src
   exposed-modules: Configuration
                  , EventLoop
+                 , Format
                  , Git
                  , Github
                  , GithubApi
@@ -42,8 +43,9 @@ library
                , file-embed
                , filepath
                , free
-               , http-types
                , github
+               , http-client
+               , http-types
                , memory
                , monad-logger
                , process
@@ -52,6 +54,7 @@ library
                , stm
                , text
                , text-format
+               , vector
                , wai
                , warp
                , warp-tls
@@ -104,6 +107,7 @@ test-suite end-to-end
   build-depends: async
                , base
                , bytestring
+               , containers
                , cryptonite
                , filepath
                -- TODO: Use the new function that really deletes directories,

--- a/src/Format.hs
+++ b/src/Format.hs
@@ -1,0 +1,22 @@
+-- Hoff -- A gatekeeper for your commits
+-- Copyright 2020 The Hoff authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- A copy of the License has been included in the root of the repository.
+
+module Format
+(
+  format,
+)
+where
+
+import Data.Text (Text)
+import Data.Text.Format.Params (Params)
+import Data.Text.Lazy (toStrict)
+
+import qualified Data.Text.Format as Text
+
+-- Like `Text.format`, but returning a strict `Text` instead of a lazy one.
+format :: Params ps => Text.Format -> ps -> Text
+format formatString params = toStrict $ Text.format formatString params

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -38,8 +38,6 @@ import Control.Monad.Logger (MonadLogger, logInfoN, logWarnN)
 import Data.Aeson
 import Data.List (intersperse)
 import Data.Text (Text)
-import Data.Text.Format.Params (Params)
-import Data.Text.Lazy (toStrict)
 import System.Directory (doesDirectoryExist)
 import System.Environment (getEnvironment)
 import System.Exit (ExitCode (ExitSuccess))
@@ -47,17 +45,12 @@ import System.FilePath ((</>))
 import System.Process.Text (readCreateProcessWithExitCode)
 
 import qualified Data.Text as Text
-import qualified Data.Text.Format as Text
 import qualified System.Process as Process
 
 import Configuration (UserConfiguration)
+import Format (format)
 
 import qualified Configuration as Config
-
--- Conversion function because of Haskell string type madness. This is just
--- Text.format, but returning a strict Text instead of a lazy one.
-format :: Params ps => Text.Format -> ps -> Text
-format formatString params = toStrict $ Text.format formatString params
 
 -- A branch is identified by its name.
 newtype Branch = Branch Text deriving (Eq)

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -53,6 +53,9 @@ import Git (Branch (..), Sha (..))
 import Prelude hiding (readFile, writeFile)
 import System.Directory (renameFile)
 
+import Data.Text.Buildable (Buildable (build))
+import Data.Text.Lazy.Builder as Text
+
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.IntMap.Strict as IntMap
@@ -128,6 +131,14 @@ data ProjectInfo = ProjectInfo
     repository :: Text
   }
   deriving (Eq, Show)
+
+-- Buildable instance for use with `format`,
+-- mainly for nicer formatting in the logs.
+instance Buildable ProjectInfo where
+  build info
+    =  Text.fromText (owner info)
+    <> Text.singleton '/'
+    <> Text.fromText (repository info)
 
 -- TODO: These default instances produce ugly json. Write a custom
 -- implementation. For now this will suffice.

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -18,8 +18,6 @@ import Data.Monoid ((<>))
 import Data.Bifunctor (second)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import Data.Text.Format.Params (Params)
-import Data.Text.Lazy (toStrict)
 import Prelude hiding (id, div, head, span)
 import Text.Blaze ((!), toValue)
 import Text.Blaze.Internal (Attribute, AttributeValue, attribute)
@@ -29,17 +27,12 @@ import Text.Blaze.Html5.Attributes (class_, charset, content, href, id, name, re
 
 import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
-import qualified Data.Text.Format as Text
 
+import Format (format)
 import Project (ProjectInfo, ProjectState, PullRequest, Owner)
 import Types (PullRequestId (..), Username (..))
 
 import qualified Project
-
--- Conversion function because of Haskell string type madness. This is just
--- Text.format, but returning a strict Text instead of a lazy one.
-format :: Params ps => Text.Format -> ps -> Text
-format formatString params = toStrict $ Text.format formatString params
 
 -- TODO: Minify this css at inclusion time.
 stylesheet :: Text

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -196,12 +196,9 @@ fakeRunGithub :: Monad m => GithubOperationFree a -> m a
 fakeRunGithub action = case action of
   GithubApi.LeaveComment _pr _body cont -> pure cont
   GithubApi.HasPushAccess username cont -> pure $ cont (username `elem` ["rachael", "deckard"])
-  GithubApi.GetPullRequestState (PullRequestId pr) cont -> case pr of
-    -- In these tests, PR 17 is always closed, PR 19 always fails, and any other
-    -- PR is always open, when we query GitHub.
-    17 -> pure $ cont GithubApi.StateClosed
-    19 -> pure $ cont GithubApi.StateUnknown
-    _  -> pure $ cont GithubApi.StateOpen
+  -- Pretend that these two GitHub API calls always fail in these tests.
+  GithubApi.GetPullRequest _pr cont -> pure $ cont Nothing
+  GithubApi.GetOpenPullRequests cont -> pure $ cont Nothing
 
 -- Runs the main loop in a separate thread, and feeds it the given events.
 runMainEventLoop


### PR DESCRIPTION
This addresses #10: bringing the Hoff state in sync with GitHub at startup.

To implement this, we add a new event, `Synchronize`, that triggers the sync. At startup we send this event to to the event loop of every project. We could trigger it from a web endpoint too in the future, if needed, but for now a `systemctl restart` should suffice.

To sync the state, we do one (or more, the endpoint is paginated, but the `github` package handles that) API call to retrieve all of the currently open pull requests.

* For PRs that are in the state, but not open on GitHub, handle them as if we got a closed event.
* For PRs that are open on GitHub, but not present in the state, get their details, and add them as new.

We need to do separate calls to get the details, because the endpoint that lists open pull requests does not include the branch and commit information.

Also includes two drive-by changes:

* Extract `format` into a module, instead of copy-pasting it everywhere. Use it in a few places to make formatting log messages more concise.
* Make it easier to control the results of operations in the tests, without having to specify all of them, by defining a record with a default value, so you can override just some results.