### PR TITLE
Make invalid states unrepresentable, fix bug

### DIFF
--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -363,8 +363,9 @@ eventLoopSpec = parallel $ do
           ]
 
         -- Extract the sha of the rebased commit from the project state.
-        let Just (_prId, pullRequest)     = Project.getIntegrationCandidate state
-            Project.Integrated rebasedSha = Project.integrationStatus pullRequest
+        let
+          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
@@ -407,8 +408,9 @@ eventLoopSpec = parallel $ do
           ]
 
         -- Extract the sha of the rebased commit from the project state.
-        let Just (_prId, pullRequest6)    = Project.getIntegrationCandidate state
-            Project.Integrated rebasedSha = Project.integrationStatus pullRequest6
+        let
+          Just (_prId, pullRequest6)      = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest6
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
@@ -416,8 +418,9 @@ eventLoopSpec = parallel $ do
 
         -- Repeat for the other pull request, which should be the candidate by
         -- now.
-        let Just (_prId, pullRequest4)     = Project.getIntegrationCandidate state'
-            Project.Integrated rebasedSha' = Project.integrationStatus pullRequest4
+        let
+          Just (_prId, pullRequest4)       = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest4
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
       history `shouldBe`
@@ -462,7 +465,8 @@ eventLoopSpec = parallel $ do
         -- result.
         let Just (prId, pullRequest4) = Project.getIntegrationCandidate state
         prId `shouldBe` pr4
-        Project.buildStatus pullRequest4 `shouldBe` BuildPending
+        let Integrated _ buildStatus = Project.integrationStatus pullRequest4
+        buildStatus `shouldBe` BuildPending
 
       -- We did not send a build status notification for c4, so it should not
       -- have been integrated.
@@ -497,8 +501,9 @@ eventLoopSpec = parallel $ do
 
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
-        let Just (_prId, pullRequest)     = Project.getIntegrationCandidate state
-            Project.Integrated rebasedSha = Project.integrationStatus pullRequest
+        let
+          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- The push should have failed, hence there should still be an
@@ -506,8 +511,9 @@ eventLoopSpec = parallel $ do
         Project.getIntegrationCandidate state' `shouldSatisfy` isJust
 
         -- Again notify build success, now for the new commit.
-        let Just (_prId, pullRequest')      = Project.getIntegrationCandidate state'
-            Project.Integrated rebasedSha'  = Project.integrationStatus pullRequest'
+        let
+          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
         state'' <- runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been
@@ -545,8 +551,8 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let
-          Just (_prId, pullRequest)     = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
         void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
@@ -586,14 +592,14 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let
-          Just (_prId, pullRequest)     = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let
-          Just (_prId, pullRequest')      = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha'  = Project.integrationStatus pullRequest'
+          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
@@ -638,8 +644,8 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let
-          Just (_prId, pullRequest)     = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- The pull request should have been integrated properly, so there


### PR DESCRIPTION
We have a bug, reproduced by #58, where we reset the integration status of a pull request, but not the build status, causing an inconsistent state. We do not care about the build status of pull requests that are not integrated, we can make invalid states unrepresentable by moving the build status into the `Integrated` integration status. This fixes the bug, and also simplifies a few other pattern matches.

Unfortunately, because these types are heavily used in Hoff, especially in the test suite, the diff is rather large. It can be reviewed commit by commit to make it more approchable.

A next step to make more invalid states unrepresentable would be to also fold the approval status and integration status into one, such that only approved pull requests can be integrated. That would be a similar change as this one, but as the diff is already  large, I prefer to do that separately.

I did not (yet) try to preserve backwards compatibility in the schema. It could be done, but we can also just make a breaking change, Hoff will scan for new pull requests at startup. It would lose two things:

* Approval status
* Previous integration result sha’s, which are used to ignore push events that we caused ourselves

If we deploy it at a quiet moment, this should not be a problem, I think that’s easier than writing a backwards-compatible parser.