### PR TITLE
Use Async instead of forkIO

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -65,7 +65,8 @@ executable hoff
   hs-source-dirs:   app
   ghc-options:      -Wall -Werror -Wincomplete-uni-patterns -Wincomplete-record-updates
 
-  build-depends: base
+  build-depends: async
+               , base
                , directory
                , github
                , hoff


### PR DESCRIPTION
The advantage of `async` is that `wait` re-throws any exceptions that happen in the forked thread, so rather than carrying on, eventually grinding everything to a halt when all queues fill up, we will now crash the process immediately.