### PR TITLE
Enforce consistency between comment and action

### DIFF
--- a/src/Project.hs
+++ b/src/Project.hs
@@ -34,6 +34,7 @@ module Project
   setApproval,
   setIntegrationCandidate,
   setIntegrationStatus,
+  setNeedsFeedback,
   updatePullRequest,
   getOwners,
   wasIntegrationAttemptFor,
@@ -74,7 +75,7 @@ data BuildStatus
 data IntegrationStatus
   = NotIntegrated
   | Integrated Sha BuildStatus
-  | Conflicted
+  | Conflicted Branch
   deriving (Eq, Show, Generic)
 
 data PullRequestStatus
@@ -94,6 +95,7 @@ data PullRequest = PullRequest
   , approvedBy          :: Maybe Username
   , integrationStatus   :: IntegrationStatus
   , integrationAttempts :: [Sha]
+  , needsFeedback       :: Bool
   }
   deriving (Eq, Show, Generic)
 
@@ -170,7 +172,8 @@ insertPullRequest (PullRequestId n) prBranch prSha prTitle prAuthor state =
         author              = prAuthor,
         approvedBy          = Nothing,
         integrationStatus   = NotIntegrated,
-        integrationAttempts = []
+        integrationAttempts = [],
+        needsFeedback       = False
       }
   in state { pullRequests = IntMap.insert n pullRequest $ pullRequests state }
 
@@ -218,17 +221,21 @@ getIntegrationCandidate state = do
   candidate     <- lookupPullRequest pullRequestId state
   return (pullRequestId, candidate)
 
-setIntegrationCandidate :: Maybe PullRequestId -> ProjectState  -> ProjectState
+setIntegrationCandidate :: Maybe PullRequestId -> ProjectState -> ProjectState
 setIntegrationCandidate pr state = state {
   integrationCandidate = pr
 }
+
+setNeedsFeedback :: PullRequestId -> Bool -> ProjectState -> ProjectState
+setNeedsFeedback pr value state =
+  updatePullRequest pr (\pullRequest -> pullRequest { needsFeedback = value }) state
 
 classifyPullRequest :: PullRequest -> PullRequestStatus
 classifyPullRequest pr = case approvedBy pr of
   Nothing -> PrStatusAwaitingApproval
   Just _  -> case integrationStatus pr of
     NotIntegrated -> PrStatusApproved
-    Conflicted    -> PrStatusFailedConflict
+    Conflicted _  -> PrStatusFailedConflict
     Integrated _ buildStatus -> case buildStatus of
       BuildPending   -> PrStatusBuildPending
       BuildSucceeded -> PrStatusIntegrated
@@ -269,7 +276,7 @@ isQueued pr = case approvedBy pr of
   Nothing -> False
   Just _  -> case integrationStatus pr of
     NotIntegrated  -> True
-    Conflicted     -> False
+    Conflicted _   -> False
     Integrated _ _ -> False
 
 -- Returns whether a pull request is in the process of being integrated (pending
@@ -279,7 +286,7 @@ isInProgress pr = case approvedBy pr of
   Nothing -> False
   Just _  -> case integrationStatus pr of
     NotIntegrated -> False
-    Conflicted    -> False
+    Conflicted _  -> False
     Integrated _ buildStatus -> case buildStatus of
       BuildPending   -> True
       BuildSucceeded -> False

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -459,7 +459,7 @@ eventLoopSpec = parallel $ do
         -- the conflicted rebase, so that the next commit can be integrated
         -- properly.
         let Just pullRequest3 = Project.lookupPullRequest pr3 state
-        Project.integrationStatus pullRequest3 `shouldBe` Conflicted
+        Project.integrationStatus pullRequest3 `shouldBe` Conflicted (Branch "master")
 
         -- The second pull request should still be pending, awaiting the build
         -- result.


### PR DESCRIPTION
Leave comments based on the actual status of the PR.

This pull request should eventually fix #53.