### PR TITLE
Post a comment when a push to github fails.

### DIFF
--- a/src/Git.hs
+++ b/src/Git.hs
@@ -266,7 +266,7 @@ runGit userConfig repoDir operation =
       -- Note: the remote branch is prefixed with 'refs/heads/' to specify the
       -- branch unambiguously. This will make Git create the branch if it does
       -- not exist.
-      result <- callGitInRepo ["push", "--force-with-lease", "--porcelain", "origin", (show sha) ++ ":refs/heads/" ++ (show branch)]
+      result <- callGitInRepo ["push", "--force", "--porcelain", "origin", (show sha) ++ ":refs/heads/" ++ (show branch)]
       -- Capture the git output and attempt to parse it
       let pushResult = case result of
             Right _ -> PushOk
@@ -276,7 +276,7 @@ runGit userConfig repoDir operation =
       -- Log if the push was rejected, include the reason why.
       case pushResult of
         PushOk -> return ()
-        PushRejected summary reason -> logWarnN $ format "warning: git push --force-with-lease failed because: {} {}" (summary, reason)
+        PushRejected summary reason -> logWarnN $ format "warning: git push --force failed because: {} {}" (summary, reason)
 
       pure $ cont pushResult
 

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -223,9 +223,9 @@ runGit userConfig repoDir operation =
       -- Note: the remote branch is prefixed with 'refs/heads/' to specify the
       -- branch unambiguously. This will make Git create the branch if it does
       -- not exist.
-      result <- callGitInRepo ["push", "--force", "origin", (show sha) ++ ":refs/heads/" ++ (show branch)]
+      result <- callGitInRepo ["push", "--force-with-lease", "origin", (show sha) ++ ":refs/heads/" ++ (show branch)]
       case result of
-        Left  _ -> logWarnN "warning: git push --force failed"
+        Left  _ -> logWarnN "warning: git push --force-with-lease failed"
         Right _ -> return ()
       pure cont
 

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -63,7 +63,6 @@ import qualified Git
 import qualified GithubApi
 import qualified Project as Pr
 import qualified Configuration as Config
-import Debug.Trace (trace)
 
 data ActionFree a
   = TryIntegrate Text (Branch, Sha) (Either IntegrationFailure Sha -> a)
@@ -132,7 +131,7 @@ runAction config = foldFree $ \case
     doGit $ ensureCloned config
     forcePushResult <- doGit $ Git.forcePush sha prBranch
     pushResult <- case forcePushResult of
-      PushRejected _ _ -> pure (trace ("TryPromote force push resulted in: " ++ show forcePushResult) forcePushResult)
+      PushRejected _ _ -> pure forcePushResult
       PushOk -> doGit $ Git.push sha (Git.Branch $ Config.branch config)
 
     pure $ cont pushResult

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -63,6 +63,7 @@ import qualified Git
 import qualified GithubApi
 import qualified Project as Pr
 import qualified Configuration as Config
+import Debug.Trace (trace)
 
 data ActionFree a
   = TryIntegrate Text (Branch, Sha) (Either IntegrationFailure Sha -> a)
@@ -131,7 +132,7 @@ runAction config = foldFree $ \case
     doGit $ ensureCloned config
     forcePushResult <- doGit $ Git.forcePush sha prBranch
     pushResult <- case forcePushResult of
-      PushRejected _ _ -> pure forcePushResult
+      PushRejected _ _ -> pure (trace ("TryPromote force push resulted in: " ++ show forcePushResult) forcePushResult)
       PushOk -> doGit $ Git.push sha (Git.Branch $ Config.branch config)
 
     pure $ cont pushResult

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -633,7 +633,7 @@ eventLoopSpec = parallel $ do
         -- the bad commit c7 is already on master. Note that origin/master is
         -- not a parent of c8, so we force-push.
         git ["fetch", "origin", "fixup"] -- The ref for commit c7f.
-        git ["push", "--force-with-lease", "origin", (show c8) ++ ":refs/heads/master"]
+        git ["push", "--force", "origin", (show c8) ++ ":refs/heads/master"]
 
         state <- runLoop Project.emptyProjectState
           [

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -633,7 +633,7 @@ eventLoopSpec = parallel $ do
         -- the bad commit c7 is already on master. Note that origin/master is
         -- not a parent of c8, so we force-push.
         git ["fetch", "origin", "fixup"] -- The ref for commit c7f.
-        git ["push", "--force", "origin", (show c8) ++ ":refs/heads/master"]
+        git ["push", "--force-with-lease", "origin", (show c8) ++ ":refs/heads/master"]
 
         state <- runLoop Project.emptyProjectState
           [

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -985,6 +985,12 @@ main = hspec $ do
           expected = Nothing
       actual `shouldBe` expected
 
+    it "can parse when tabs are missing (by returning Nothing)" $ do
+      let raw = Text.pack "To github.com:foo/bar.git\n=trefs/heads/foobar:refs/heads/foobar[up to date]\nDone"
+          actual = parsePorcelainPushOutput raw
+          expected = Nothing
+      actual `shouldBe` expected
+
     it "can handle gibberish input (by returning Nothing)" $ do
       let raw = Text.pack "askjdlfhaosdyuro3\t\t\t\n\n\n\t\t\tasasdkjaslkdjalksjd"
           actual = parsePorcelainPushOutput raw


### PR DESCRIPTION
Using `--force` in `git push` can be destructive as it does not take into account the state of the remote. With `--force-with-lease` the push will fail if the remote is in a unexpected state. It is better to exit early during the push that to carry on and cause trouble on the remote.
