### PR TITLE
Include PR title in merge commit messages

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -421,11 +421,12 @@ tryIntegratePullRequest pr state =
   let
     PullRequestId prNumber = pr
     pullRequest  = fromJust $ Pr.lookupPullRequest pr state
+    title = Pr.title pullRequest
     Username approvedBy = fromJust $ Pr.approvedBy pullRequest
     candidateSha = Pr.sha pullRequest
     candidateRef = getPullRequestRef pr
     candidate = (candidateRef, candidateSha)
-    mergeMessage = format "Merge #{}\n\nApproved-by: {}" (prNumber, approvedBy)
+    mergeMessage = format "Merge #{}: {}\n\nApproved-by: {}" (prNumber, title, approvedBy)
   in do
     result <- tryIntegrate mergeMessage candidate
     case result of

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -377,7 +377,7 @@ main = hspec $ do
       actions1 `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
         , ALeaveComment (PullRequestId 1)
             "Failed to rebase, please rebase manually using\n\n\
             \    git rebase --interactive --autosquash origin/master p"
@@ -403,7 +403,7 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved by @deckard, waiting for rebase at the front of the queue."
@@ -422,7 +422,7 @@ main = hspec $ do
       actionsPermuted `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved by @deckard, rebasing now."
-        , ATryIntegrate "Merge #2\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "dec")
+        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "dec")
         , ALeaveComment (PullRequestId 2) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, waiting for rebase at the front of the queue."
@@ -456,12 +456,12 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved by @deckard, waiting for rebase at the front of the queue."
         , ALeaveComment (PullRequestId 1) "Abandoning this pull request because it was closed."
-        , ATryIntegrate "Merge #2\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "dec")
+        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "dec")
         , ALeaveComment (PullRequestId 2) "Rebased as b72, waiting for CI …"
         ]
 
@@ -570,7 +570,7 @@ main = hspec $ do
       Project.integrationStatus pullRequest `shouldBe` Project.Integrated (Sha "38c") Project.BuildPending
       prId    `shouldBe` PullRequestId 1
       actions `shouldBe`
-        [ ATryIntegrate "Merge #1\n\nApproved-by: fred" (Branch "refs/pull/1/head", Sha "f34")
+        [ ATryIntegrate "Merge #1: Untitled\n\nApproved-by: fred" (Branch "refs/pull/1/head", Sha "f34")
         , ALeaveComment (PullRequestId 1) "Rebased as 38c, waiting for CI \x2026"
         ]
 
@@ -628,7 +628,7 @@ main = hspec $ do
       Project.integrationAttempts pullRequest' `shouldBe` [Sha "38d"]
       actions `shouldBe`
         [ ATryPromote (Branch "results/rachael") (Sha "38d")
-        , ATryIntegrate "Merge #1\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "f35")
+        , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "f35")
         , ALeaveComment (PullRequestId 1) "Rebased as 38e, waiting for CI \x2026"
         ]
 
@@ -667,13 +667,13 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
           -- The first rebase succeeds.
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
           -- The first promotion attempt fails
         , ATryPromote (Branch "n7") (Sha "b71")
           -- The second rebase fails.
-        , ATryIntegrate "Merge #1\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
         , ALeaveComment (PullRequestId 1)
             "Failed to rebase, please rebase manually using\n\n\
             \    git rebase --interactive --autosquash origin/master n7"
@@ -716,7 +716,7 @@ main = hspec $ do
           Just (cId, _candidate) = Project.getIntegrationCandidate state'
       cId     `shouldBe` PullRequestId 2
       actions `shouldBe`
-        [ ATryIntegrate "Merge #2\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "f37")
+        [ ATryIntegrate "Merge #2: Add my test results\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "f37")
         , ALeaveComment (PullRequestId 2) "Rebased as 38e, waiting for CI \x2026"
         ]
 
@@ -743,7 +743,7 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
         , ALeaveComment (PullRequestId 1) "The build failed."
         , AIsReviewer "deckard"


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

With this patch, the merge commit message changes from `Merge #${pr_num}` to `Merge #${pr_num}: ${pr_title}`, making the git history slightly more informative. This fixes #61.