### PR TITLE
Add "approved for" to a PR's state

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -52,6 +52,8 @@ import Configuration (ProjectConfiguration, TriggerConfiguration)
 import Format (format)
 import Git (Branch (..), GitOperation, GitOperationFree, PushResult (..), Sha (..))
 import GithubApi (GithubOperation, GithubOperationFree)
+import Project (Approval (..))
+import Project (ApprovedFor (..))
 import Project (BuildStatus (..))
 import Project (IntegrationStatus (..))
 import Project (PullRequestStatus (..))
@@ -274,11 +276,12 @@ handlePullRequestClosed pr state = Pr.deletePullRequest pr <$>
         pure state { Pr.integrationCandidate = Nothing }
       _notCandidatePr -> pure state
 
--- Returns whether the message is a command that instructs us to merge the PR.
+-- Returns the approval type contained in the given text, if the message is a
+-- command that instructs us to merge the PR.
 -- If the trigger prefix is "@hoffbot", a command "@hoffbot merge" would
--- indicate approval.
-isMergeCommand :: TriggerConfiguration -> Text -> Bool
-isMergeCommand config message =
+-- indicate the `Merge` approval type.
+parseMergeCommand :: TriggerConfiguration -> Text -> Maybe ApprovedFor
+parseMergeCommand config message =
   let
     messageCaseFold = Text.toCaseFold $ Text.strip message
     prefixCaseFold = Text.toCaseFold $ Config.commentPrefix config
@@ -286,15 +289,16 @@ isMergeCommand config message =
     -- Check if the prefix followed by ` merge` occurs within the message. We opt
     -- to include the space here, instead of making it part of the prefix, because
     -- having the trailing space in config is something that is easy to get wrong.
-    (mappend prefixCaseFold " merge") `Text.isInfixOf` messageCaseFold
+    if (mappend prefixCaseFold " merge") `Text.isInfixOf` messageCaseFold
+    then Just Merge
+    else Nothing
 
--- Mark the pull request as approved by the approver, and leave a comment to
--- acknowledge that.
-approvePullRequest :: PullRequestId -> Username -> ProjectState -> Action ProjectState
-approvePullRequest pr approver state =
+-- Mark the pull request as approved, and leave a comment to acknowledge that.
+approvePullRequest :: PullRequestId -> Approval -> ProjectState -> Action ProjectState
+approvePullRequest pr approval state =
   pure $ Pr.updatePullRequest pr
     (\pullRequest -> pullRequest
-      { Pr.approvedBy = Just approver
+      { Pr.approval = Just approval
       , Pr.needsFeedback = True
       })
     state
@@ -313,12 +317,13 @@ handleCommentAdded triggerConfig pr author body state =
     -- frequently, but most comments are not merge commands, and checking that
     -- a user has push access requires an API call.
     then do
-      isApproved <- if isMergeCommand triggerConfig body
+      let approvalType = parseMergeCommand triggerConfig body
+      isApproved <- if isJust approvalType
         then isReviewer author
         else pure False
       if isApproved
         -- The PR has now been approved by the author of the comment.
-        then approvePullRequest pr author state
+        then approvePullRequest pr (Approval author (fromJust approvalType)) state
         else pure state
 
     -- If the pull request is not in the state, ignore the comment.
@@ -422,7 +427,7 @@ tryIntegratePullRequest pr state =
     PullRequestId prNumber = pr
     pullRequest  = fromJust $ Pr.lookupPullRequest pr state
     title = Pr.title pullRequest
-    Username approvedBy = fromJust $ Pr.approvedBy pullRequest
+    Username approvedBy = approver $ fromJust $ Pr.approval pullRequest
     candidateSha = Pr.sha pullRequest
     candidateRef = getPullRequestRef pr
     candidate = (candidateRef, candidateSha)
@@ -454,7 +459,7 @@ pushCandidate (pullRequestId, pullRequest) state = do
   -- Look up the sha that will be pushed to the target branch. Also assert that
   -- the pull request has really been approved and built successfully. If it was
   -- not, there is a bug in the program.
-  let approved  = isJust $ Pr.approvedBy pullRequest
+  let approved  = isJust $ Pr.approval pullRequest
       status    = Pr.integrationStatus pullRequest
       prBranch  = Pr.branch pullRequest
       newHead   = assert approved $ case status of
@@ -490,11 +495,11 @@ describeStatus :: PullRequestId -> PullRequest -> ProjectState -> Text
 describeStatus prId pr state = case Pr.classifyPullRequest pr of
   PrStatusAwaitingApproval -> "Pull request awaiting approval."
   PrStatusApproved ->
-    let approver = fromJust $ Pr.approvedBy pr
+    let approvedBy = approver $ fromJust $ Pr.approval pr
     in case Pr.getQueuePosition prId state of
-      0 -> format "Pull request approved by @{}, rebasing now." [approver]
-      1 -> format "Pull request approved by @{}, waiting for rebase at the front of the queue." [approver]
-      n -> format "Pull request approved by @{}, waiting for rebase behind {} pull requests." (approver, n)
+      0 -> format "Pull request approved by @{}, rebasing now." [approvedBy]
+      1 -> format "Pull request approved by @{}, waiting for rebase at the front of the queue." [approvedBy]
+      n -> format "Pull request approved by @{}, waiting for rebase behind {} pull requests." (approvedBy, n)
   PrStatusBuildPending ->
     let Sha sha = fromJust $ getIntegrationSha pr
     in Text.concat ["Rebased as ", sha, ", waiting for CI …"]

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -10,6 +10,8 @@
 
 module Project
 (
+  Approval (..),
+  ApprovedFor (..),
   BuildStatus (..),
   IntegrationStatus (..),
   ProjectInfo (..),
@@ -87,12 +89,28 @@ data PullRequestStatus
   | PrStatusFailedBuild      -- Integrated, but the build failed.
   deriving (Eq)
 
+-- A PR can currently be approved to be merged with "<prefix> merge".
+-- Later on we intend to add different approval commands that trigger different
+-- behaviour, and this enumeration will distinguish these cases.
+data ApprovedFor
+  = Merge
+  -- | MergeAndDeploy
+  deriving (Eq, Show, Generic)
+
+-- For a PR to be approved a specific user must give a specific approval
+-- command, i.e. either just "merge" or "merge and deploy".
+data Approval = Approval
+  { approver :: Username
+  , approvedFor :: ApprovedFor
+  }
+  deriving (Eq, Show, Generic)
+
 data PullRequest = PullRequest
   { sha                 :: Sha
   , branch              :: Branch
   , title               :: Text
   , author              :: Username
-  , approvedBy          :: Maybe Username
+  , approval            :: Maybe Approval
   , integrationStatus   :: IntegrationStatus
   , integrationAttempts :: [Sha]
   , needsFeedback       :: Bool
@@ -127,11 +145,15 @@ instance Buildable ProjectInfo where
 
 instance FromJSON BuildStatus
 instance FromJSON IntegrationStatus
+instance FromJSON ApprovedFor
+instance FromJSON Approval
 instance FromJSON ProjectState
 instance FromJSON PullRequest
 
 instance ToJSON BuildStatus where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON IntegrationStatus where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+instance ToJSON ApprovedFor where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+instance ToJSON Approval where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON ProjectState where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON PullRequest where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 
@@ -170,7 +192,7 @@ insertPullRequest (PullRequestId n) prBranch prSha prTitle prAuthor state =
         branch              = prBranch,
         title               = prTitle,
         author              = prAuthor,
-        approvedBy          = Nothing,
+        approval            = Nothing,
         integrationStatus   = NotIntegrated,
         integrationAttempts = [],
         needsFeedback       = False
@@ -197,9 +219,9 @@ updatePullRequest (PullRequestId n) f state = state {
 }
 
 -- Marks the pull request as approved by somebody or nobody.
-setApproval :: PullRequestId -> Maybe Username -> ProjectState -> ProjectState
-setApproval pr newApprovedBy = updatePullRequest pr changeApproval
-  where changeApproval pullRequest = pullRequest { approvedBy = newApprovedBy }
+setApproval :: PullRequestId -> Maybe Approval -> ProjectState -> ProjectState
+setApproval pr newApproval = updatePullRequest pr changeApproval
+  where changeApproval pullRequest = pullRequest { approval = newApproval }
 
 -- Sets the integration status for a pull request.
 setIntegrationStatus :: PullRequestId -> IntegrationStatus -> ProjectState -> ProjectState
@@ -231,7 +253,7 @@ setNeedsFeedback pr value state =
   updatePullRequest pr (\pullRequest -> pullRequest { needsFeedback = value }) state
 
 classifyPullRequest :: PullRequest -> PullRequestStatus
-classifyPullRequest pr = case approvedBy pr of
+classifyPullRequest pr = case approval pr of
   Nothing -> PrStatusAwaitingApproval
   Just _  -> case integrationStatus pr of
     NotIntegrated -> PrStatusApproved
@@ -256,7 +278,7 @@ filterPullRequestsBy p =
 
 -- Returns the pull requests that have been approved, in order of ascending id.
 approvedPullRequests :: ProjectState -> [PullRequestId]
-approvedPullRequests = filterPullRequestsBy $ isJust . approvedBy
+approvedPullRequests = filterPullRequestsBy $ isJust . approval
 
 -- Returns the number of pull requests that will be rebased and checked on CI
 -- before the PR with the given id will be rebased, in case no other pull
@@ -272,7 +294,7 @@ getQueuePosition pr state =
 -- Returns whether a pull request is queued for merging, but not already in
 -- progress (pending build results).
 isQueued :: PullRequest -> Bool
-isQueued pr = case approvedBy pr of
+isQueued pr = case approval pr of
   Nothing -> False
   Just _  -> case integrationStatus pr of
     NotIntegrated  -> True
@@ -282,7 +304,7 @@ isQueued pr = case approvedBy pr of
 -- Returns whether a pull request is in the process of being integrated (pending
 -- build results).
 isInProgress :: PullRequest -> Bool
-isInProgress pr = case approvedBy pr of
+isInProgress pr = case approval pr of
   Nothing -> False
   Just _  -> case integrationStatus pr of
     NotIntegrated -> False

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -29,7 +29,7 @@ import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
 
 import Format (format)
-import Project (ProjectInfo, ProjectState, PullRequest, Owner)
+import Project (Approval (..), ProjectInfo, ProjectState, PullRequest, Owner)
 import Types (PullRequestId (..), Username (..))
 
 import qualified Project
@@ -237,8 +237,8 @@ viewPullRequest info (PullRequestId n) pullRequest =
 viewPullRequestWithApproval :: ProjectInfo -> PullRequestId -> PullRequest -> Html
 viewPullRequestWithApproval info prId pullRequest = do
   viewPullRequest info prId pullRequest
-  case Project.approvedBy pullRequest of
-    Just (Username username) ->
+  case Project.approval pullRequest of
+    Just Approval { approver = Username username } ->
       span ! class_ "review" $ do
         void "Approved by "
         -- TODO: Link to approval comment, not just username.


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

This PR alters Hoff to include a "approval type" in a PR's state.
The current means of approving a PR (`<prefix> merge`) always mark a PR to be merged, but we are planning to add another approval command (`<prefix> merge and deploy`) to trigger different behaviour if the resulting merge succeeds.

This PR:
 - Defines a new enumeration `ApprovedFor` that for now contains just one option `Merge`,
 - Defines a type alias `Approval = Approval { approver :: Username, approvedFor :: ApprovedFor }`, to model that a user approves a PR with a specific approval type,
 - Replaces `PullRequest`'s `approvedBy :: Maybe Username` with `approval :: Maybe Approval`,
 - Alters `isMergeCommand` to return `Maybe ApprovedFor` depending on the merge command used,
 - Alters the various sites where `approvedBy` was used to use `approval` instead, and
 - Updates the tests to use `approval` instead of `approvedBy`.