### PR TITLE
Add "merge and deploy" command

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -286,12 +286,20 @@ parseMergeCommand config message =
     messageCaseFold = Text.toCaseFold $ Text.strip message
     prefixCaseFold = Text.toCaseFold $ Config.commentPrefix config
   in
-    -- Check if the prefix followed by ` merge` occurs within the message. We opt
-    -- to include the space here, instead of making it part of the prefix, because
-    -- having the trailing space in config is something that is easy to get wrong.
-    if (mappend prefixCaseFold " merge") `Text.isInfixOf` messageCaseFold
-    then Just Merge
-    else Nothing
+    -- Check if the prefix followed by ` merge and deploy` occurs within the message.
+    -- We opt to include the space here, instead of making it part of the
+    -- prefix, because having the trailing space in config is something that is
+    -- easy to get wrong.
+    -- Note that because "merge" is an infix of "merge and deploy" we need to
+    -- check for the "merge and deploy" command first: if this order were
+    -- reversed all "merge and deploy" commands would be detected as a Merge
+    -- command.
+    if (prefixCaseFold <> " merge and deploy") `Text.isInfixOf` messageCaseFold
+    then Just MergeAndDeploy
+    else
+      if (prefixCaseFold <> " merge") `Text.isInfixOf` messageCaseFold
+      then Just Merge
+      else Nothing
 
 -- Mark the pull request as approved, and leave a comment to acknowledge that.
 approvePullRequest :: PullRequestId -> Approval -> ProjectState -> Action ProjectState
@@ -495,11 +503,15 @@ describeStatus :: PullRequestId -> PullRequest -> ProjectState -> Text
 describeStatus prId pr state = case Pr.classifyPullRequest pr of
   PrStatusAwaitingApproval -> "Pull request awaiting approval."
   PrStatusApproved ->
-    let approvedBy = approver $ fromJust $ Pr.approval pr
+    let
+      Approval approvedBy approvalType = fromJust $ Pr.approval pr
+      approvalCommand = case approvalType of
+        Merge -> "merge"
+        MergeAndDeploy -> "merge and deploy"
     in case Pr.getQueuePosition prId state of
-      0 -> format "Pull request approved by @{}, rebasing now." [approvedBy]
-      1 -> format "Pull request approved by @{}, waiting for rebase at the front of the queue." [approvedBy]
-      n -> format "Pull request approved by @{}, waiting for rebase behind {} pull requests." (approvedBy, n)
+      0 -> format "Pull request approved for {} by @{}, rebasing now." [approvalCommand, approvedBy]
+      1 -> format "Pull request approved for {} by @{}, waiting for rebase at the front of the queue." [approvalCommand, approvedBy]
+      n -> format "Pull request approved for {} by @{}, waiting for rebase behind {} pull requests." (approvalCommand, approvedBy, n)
   PrStatusBuildPending ->
     let Sha sha = fromJust $ getIntegrationSha pr
     in Text.concat ["Rebased as ", sha, ", waiting for CI …"]

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -89,12 +89,12 @@ data PullRequestStatus
   | PrStatusFailedBuild      -- Integrated, but the build failed.
   deriving (Eq)
 
--- A PR can currently be approved to be merged with "<prefix> merge".
--- Later on we intend to add different approval commands that trigger different
--- behaviour, and this enumeration will distinguish these cases.
+-- A PR can be approved to be merged with "<prefix> merge", or it can be
+-- approved to be merged and also deployed with "<prefix> merge and deploy".
+-- This enumeration distinguishes these cases.
 data ApprovedFor
   = Merge
-  -- | MergeAndDeploy
+  | MergeAndDeploy
   deriving (Eq, Show, Generic)
 
 -- For a PR to be approved a specific user must give a specific approval

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -29,7 +29,7 @@ import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
 
 import Format (format)
-import Project (Approval (..), ProjectInfo, ProjectState, PullRequest, Owner)
+import Project (Approval (..), ApprovedFor (..), ProjectInfo, ProjectState, PullRequest, Owner)
 import Types (PullRequestId (..), Username (..))
 
 import qualified Project
@@ -238,9 +238,12 @@ viewPullRequestWithApproval :: ProjectInfo -> PullRequestId -> PullRequest -> Ht
 viewPullRequestWithApproval info prId pullRequest = do
   viewPullRequest info prId pullRequest
   case Project.approval pullRequest of
-    Just Approval { approver = Username username } ->
+    Just Approval { approver = Username username, approvedFor = approvalType } ->
       span ! class_ "review" $ do
-        void "Approved by "
+        let approvedAction = case approvalType of
+              Merge -> "merge"
+              MergeAndDeploy -> "merge and deploy"
+        toHtml $ format "Approved for {} by " [approvedAction :: String]
         -- TODO: Link to approval comment, not just username.
         let url = Text.append "https://github.com/" username
         a ! href (toValue url) $ toHtml username

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -376,7 +376,7 @@ main = hspec $ do
       actions0 `shouldBe` []
       actions1 `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
         , ALeaveComment (PullRequestId 1)
             "Failed to rebase, please rebase manually using\n\n\
@@ -390,11 +390,11 @@ main = hspec $ do
           $ Project.insertPullRequest (PullRequestId 2) (Branch "s") (Sha "dec") "Some PR" (Username "rachael")
           $ Project.insertPullRequest (PullRequestId 3) (Branch "s") (Sha "f16") "Another PR" (Username "rachael")
           $ Project.emptyProjectState
-        -- Approve pull request in order of ascending id.
+        -- Approve pull request in order of ascending id, mark the last PR for deployment.
         events =
           [ CommentAdded (PullRequestId 1) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 2) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 3) "deckard" "@bot merge"
+          , CommentAdded (PullRequestId 3) "deckard" "@bot merge and deploy"
           ]
         -- For this test, we assume all integrations and pushes succeed.
         results = defaultResults { resultIntegrate = [Right (Sha "b71")] }
@@ -402,13 +402,13 @@ main = hspec $ do
         actions = snd $ run $ handleEventsTest events state
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "Pull request approved by @deckard, waiting for rebase at the front of the queue."
+        , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 3) "Pull request approved by @deckard, waiting for rebase behind 2 pull requests."
+        , ALeaveComment (PullRequestId 3) "Pull request approved for merge and deploy by @deckard, waiting for rebase behind 2 pull requests."
         ]
 
       -- Approve pull requests, but not in order of ascending id.
@@ -421,13 +421,13 @@ main = hspec $ do
         actionsPermuted = snd $ run $ handleEventsTest eventsPermuted state
       actionsPermuted `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "Pull request approved by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "dec")
         , ALeaveComment (PullRequestId 2) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, waiting for rebase at the front of the queue."
+        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 3) "Pull request approved by @deckard, waiting for rebase behind 2 pull requests."
+        , ALeaveComment (PullRequestId 3) "Pull request approved for merge by @deckard, waiting for rebase behind 2 pull requests."
         ]
 
     it "abandons integration when a pull request is closed" $ do
@@ -455,11 +455,11 @@ main = hspec $ do
       Project.integrationCandidate state' `shouldBe` Just (PullRequestId 2)
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "Pull request approved by @deckard, waiting for rebase at the front of the queue."
+        , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
         , ALeaveComment (PullRequestId 1) "Abandoning this pull request because it was closed."
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "dec")
         , ALeaveComment (PullRequestId 2) "Rebased as b72, waiting for CI …"
@@ -666,7 +666,7 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
           -- The first rebase succeeds.
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
@@ -742,7 +742,7 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "Pull request approved by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
         , ALeaveComment (PullRequestId 1) "The build failed."


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

This PR adds a new command "{prefix} merge and deploy" to Hoff.
This command also approves a PR for rebase and merge, and currently triggers the same merge behaviour as "{prefix} merge".

Changes:
  - A new value `MergeAndDeploy` is added to `ApprovedFor`.
  - `parseMergeCommand` now searches for the "{prefix} merge and deploy" infix before searching for "{prefix} merge", returning `Just MergeAndDeploy` if found.
  - The web interface will show which merge command was used to approve a PR:
    - Approved PRs show the text "Approved by {user}" in the current version of Hoff,
    - PRs approved with "{prefix} merge and deploy" now show "Approved for merge and deploy by {user}",
    - PRs approved with "{prefix} merge" now show "Approved for merge by {user}".
  - The approval acknowledgement message now echoes the command that was used to approve the PR, i.e. Hoff will comment "Pull request was approved (for merge | for merge and deploy) by {user}, …" depending on which command was used.
  - The tests were updated to adjust to the new expected messages and to include a use of "merge and deploy" in the testcases.