### PR TITLE
Add `Auto-deploy:` trailer to merge message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.18.0
+
+Released 2021-01-27.
+
+**Compatibility**:
+
+ * The state serialization format of 0.18.0 is incompatible with 0.17.0. The
+   recommended way to update is to stop Hoff 0.17.0 at a quiet time when no
+   builds are in progress, delete the state files, and start 0.18.0. Hoff will
+   scan for open pull requests at startup, but approval status will be lost.
+
+   The new version of Hoff will automatically create a new state file using the
+   new format when run.
+
+Changes:
+
+ - Add `Auto-deploy: false` as a Git trailer to merge commit messages of PRs
+   approved with the "{prefix} merge" command.
+
+   This change does not affect single-commit PRs, as these are merged by
+   fast-forwarding the target branch and don't have a merge message.
+
+ - Add support for a new merge command "{prefix} merge and deploy".
+
+   When this command is used Hoff will perform a rebase and merge in the same
+   way as is done in response to the "merge" command.
+
+   Unlike the "merge" command, Hoff will
+     - Always create a merge commit, even for single-commit PRs, and
+     - Append `Auto-deploy: true` (instead of `Auto-deploy: false`) to the
+       commit message of the resulting merge commit.
+
+       This information can later be used in a CI/CD pipeline to trigger an
+       automatic deploy.
+
 ## 0.17.0
 
 Released 2021-01-06.

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -68,7 +68,11 @@ candidateState pr prBranch prSha prAuthor approvedBy candidateSha =
 -- Types and functions to mock running an action without actually doing anything.
 
 data ActionFlat
-  = ATryIntegrate Text (Branch, Sha)
+  = ATryIntegrate
+    { mergeMessage :: Text
+    , integrationCandidate :: (Branch, Sha)
+    , alwaysAddMergeCommit :: Bool
+    }
   | ATryPromote Branch Sha
   | ALeaveComment PullRequestId Text
   | AIsReviewer Username
@@ -150,8 +154,8 @@ runActionRws =
     isReviewer username = username == "deckard"
   in
     foldFree $ \case
-      TryIntegrate msg candidate cont -> do
-        Rws.tell [ATryIntegrate msg candidate]
+      TryIntegrate msg candidate alwaysAddMergeCommit' cont -> do
+        Rws.tell [ATryIntegrate msg candidate alwaysAddMergeCommit']
         cont <$> takeResultIntegrate
       TryPromote prBranch headSha cont -> do
         Rws.tell [ATryPromote prBranch headSha]
@@ -377,7 +381,7 @@ main = hspec $ do
       actions1 `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1)
             "Failed to rebase, please rebase manually using\n\n\
             \    git rebase --interactive --autosquash origin/master p"
@@ -403,7 +407,7 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
@@ -422,7 +426,7 @@ main = hspec $ do
       actionsPermuted `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "dec")
+        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "dec") False
         , ALeaveComment (PullRequestId 2) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
@@ -456,12 +460,12 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a38")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
         , ALeaveComment (PullRequestId 1) "Abandoning this pull request because it was closed."
-        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "dec")
+        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "dec") False
         , ALeaveComment (PullRequestId 2) "Rebased as b72, waiting for CI …"
         ]
 
@@ -554,6 +558,26 @@ main = hspec $ do
       -- obtained its details.
       actions `shouldBe` [AGetOpenPullRequests]
 
+    it "recognizes 'merge and deploy' commands as the proper ApprovedFor value" $ do
+      let
+        prId = PullRequestId 1
+        state = singlePullRequestState prId (Branch "p") (Sha "abc1234") "tyrell"
+
+        event = CommentAdded prId "deckard" "@bot merge and deploy"
+
+        results = defaultResults { resultIntegrate = [Right (Sha "def2345")] }
+        (state', actions) = runActionCustom results $ handleEventTest event state
+
+      actions `shouldBe`
+        [ AIsReviewer "deckard"
+        , ALeaveComment prId "Pull request approved for merge and deploy by @deckard, rebasing now."
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\n" (Branch "refs/pull/1/head", Sha "abc1234") True
+        , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
+        ]
+
+      fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
+        (\pr -> Project.approval pr== Just (Approval (Username "deckard") Project.MergeAndDeploy))
+
   describe "Logic.proceedUntilFixedPoint" $ do
 
     it "finds a new candidate" $ do
@@ -570,7 +594,7 @@ main = hspec $ do
       Project.integrationStatus pullRequest `shouldBe` Project.Integrated (Sha "38c") Project.BuildPending
       prId    `shouldBe` PullRequestId 1
       actions `shouldBe`
-        [ ATryIntegrate "Merge #1: Untitled\n\nApproved-by: fred" (Branch "refs/pull/1/head", Sha "f34")
+        [ ATryIntegrate "Merge #1: Untitled\n\nApproved-by: fred\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "f34") False
         , ALeaveComment (PullRequestId 1) "Rebased as 38c, waiting for CI \x2026"
         ]
 
@@ -628,7 +652,7 @@ main = hspec $ do
       Project.integrationAttempts pullRequest' `shouldBe` [Sha "38d"]
       actions `shouldBe`
         [ ATryPromote (Branch "results/rachael") (Sha "38d")
-        , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "f35")
+        , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "f35") False
         , ALeaveComment (PullRequestId 1) "Rebased as 38e, waiting for CI \x2026"
         ]
 
@@ -667,13 +691,13 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a39") False
           -- The first rebase succeeds.
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
           -- The first promotion attempt fails
         , ATryPromote (Branch "n7") (Sha "b71")
           -- The second rebase fails.
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a39") False
         , ALeaveComment (PullRequestId 1)
             "Failed to rebase, please rebase manually using\n\n\
             \    git rebase --interactive --autosquash origin/master n7"
@@ -716,7 +740,7 @@ main = hspec $ do
           Just (cId, _candidate) = Project.getIntegrationCandidate state'
       cId     `shouldBe` PullRequestId 2
       actions `shouldBe`
-        [ ATryIntegrate "Merge #2: Add my test results\n\nApproved-by: deckard" (Branch "refs/pull/2/head", Sha "f37")
+        [ ATryIntegrate "Merge #2: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "f37") False
         , ALeaveComment (PullRequestId 2) "Rebased as 38e, waiting for CI \x2026"
         ]
 
@@ -743,7 +767,7 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard" (Branch "refs/pull/1/head", Sha "a39")
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a39") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
         , ALeaveComment (PullRequestId 1) "The build failed."
         , AIsReviewer "deckard"


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

This PR alters Hoff's merge behaviour for PRs approved with the "merge and deploy" command.
When a PR is approved with this command, Hoff will
  - Always create a merge commit (even for single-commit PRs), and
  - Set a trailer `Auto-deploy: true` in this merge commit's message.

The behaviour of the "merge" command is mostly unaffected: Hoff will still merge single-commit PRs by fast-forwarding, but will add a `Auto-deploy: false` trailer to the merge commit messages created to merge PRs with multiple commits.

Changes in this PR:
 - Alter `Git.tryIntegrate`'s signature to accept a new boolean flag `alwaysMergeCommit`, which causes a merge commit to be created even for single-commit PRs.
 - Alter `Logic.tryIntegrate`, `Logic.ActionFree` and `Logic.runAction` to propagate this new flag.
 - Alter `Logic.tryIntegratePullRequest` to add a `Auto-deploy: true` trailer to the merge commit if "merge and deploy" was used, `Auto-deploy: false` otherwise.
 - Alter `Logic.tryIntegratePullRequest` to set `alwaysMergeCommit` to `True` if the "merge and deploy" command was used, `False` otherwise.
 - Update tests to adjust to new trailer and trailing newline in messages passed to Git.
 - Update changelog.