### PR TITLE
Add order on PR approval

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -65,14 +65,14 @@ initializeProjectState :: FilePath -> IO ProjectState
 initializeProjectState fname = do
   exists <- FileSystem.doesFileExist fname
   if exists then do
-    maybeState <- loadProjectState fname
-    case maybeState of
-      Just projectState -> do
+    eitherState <- loadProjectState fname
+    case eitherState of
+      Right projectState -> do
         putStrLn $ "Loaded project state from '" ++ fname ++ "'."
         return projectState
-      Nothing -> do
+      Left msg -> do
         -- Fail loudly if something is wrong, and abort the program.
-        die $ "Failed to parse project state in '" ++ fname ++ "'.\n" ++
+        die $ "Failed to parse project state in '" ++ fname ++ "' with error " ++ msg ++ ".\n" ++
               "Please repair or remove the file."
   else do
     putStrLn $ "File '" ++ fname ++ "' not found, starting with an empty state."

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -37,6 +37,7 @@ module Project
   needsTag,
   displayApproval,
   setApproval,
+  newApprovalOrder,
   setIntegrationCandidate,
   setIntegrationStatus,
   setNeedsFeedback,
@@ -50,7 +51,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.ByteString (readFile)
 import Data.ByteString.Lazy (writeFile)
 import Data.IntMap.Strict (IntMap)
-import Data.List (intersect, nub)
+import Data.List (intersect, nub, sortBy)
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import GHC.Generics
@@ -106,6 +107,7 @@ data ApprovedFor
 data Approval = Approval
   { approver    :: Username
   , approvedFor :: ApprovedFor
+  , approvalOrder :: Int
   }
   deriving (Eq, Show, Generic)
 
@@ -122,9 +124,9 @@ data PullRequest = PullRequest
   deriving (Eq, Show, Generic)
 
 data ProjectState = ProjectState
-  {
-    pullRequests         :: IntMap PullRequest,
-    integrationCandidate :: Maybe PullRequestId
+  { pullRequests              :: IntMap PullRequest
+  , integrationCandidate      :: Maybe PullRequestId
+  , pullRequestApprovalIndex  :: Int
   }
   deriving (Eq, Show, Generic)
 
@@ -163,8 +165,8 @@ instance ToJSON PullRequest where toEncoding = Aeson.genericToEncoding Aeson.def
 
 -- Reads and parses the state. Returns Nothing if parsing failed, but crashes if
 -- the file could not be read.
-loadProjectState :: FilePath -> IO (Maybe ProjectState)
-loadProjectState = fmap Aeson.decodeStrict' . readFile
+loadProjectState :: FilePath -> IO (Either String ProjectState)
+loadProjectState = fmap Aeson.eitherDecodeStrict' . readFile
 
 saveProjectState :: FilePath -> ProjectState -> IO ()
 saveProjectState fname state = do
@@ -177,7 +179,8 @@ saveProjectState fname state = do
 emptyProjectState :: ProjectState
 emptyProjectState = ProjectState {
   pullRequests         = IntMap.empty,
-  integrationCandidate = Nothing
+  integrationCandidate = Nothing,
+  pullRequestApprovalIndex = 0
 }
 
 -- Inserts a new pull request into the project, with approval set to Nothing,
@@ -227,6 +230,11 @@ setApproval :: PullRequestId -> Maybe Approval -> ProjectState -> ProjectState
 setApproval pr newApproval = updatePullRequest pr changeApproval
   where changeApproval pullRequest = pullRequest { approval = newApproval }
 
+newApprovalOrder :: ProjectState -> (Int, ProjectState)
+newApprovalOrder state =
+  let index = pullRequestApprovalIndex state
+  in (index, state{ pullRequestApprovalIndex = index + 1})
+
 -- Sets the integration status for a pull request.
 setIntegrationStatus :: PullRequestId -> IntegrationStatus -> ProjectState -> ProjectState
 setIntegrationStatus pr newStatus = updatePullRequest pr changeIntegrationStatus
@@ -274,10 +282,23 @@ classifyPullRequests state = IntMap.foldMapWithKey aux (pullRequests state)
     aux i pr = [(PullRequestId i, pr, classifyPullRequest pr)]
 
 -- Returns the ids of the pull requests that satisfy the predicate, in ascending
--- order.
+-- order. The ids are sorted by the approval order, with not yet approved PRs
+-- at the end of the list.
 filterPullRequestsBy :: (PullRequest -> Bool) -> ProjectState -> [PullRequestId]
 filterPullRequestsBy p =
-  fmap PullRequestId . IntMap.keys . IntMap.filter p . pullRequests
+  fmap PullRequestId
+  . map fst
+  . sortBy comp
+  . IntMap.toList
+  . IntMap.filter p
+  . pullRequests
+  where
+    -- Compare the approval orders, prefer a Just over a Nothing
+    comp x y = comp' (approvalOrder <$> approval (snd x)) (approvalOrder <$> approval (snd y))
+    comp' Nothing Nothing = EQ
+    comp' (Just _) Nothing = LT
+    comp' Nothing (Just _) = GT
+    comp' (Just n) (Just m) = compare n m
 
 -- Returns the pull requests that have been approved, in order of ascending id.
 approvedPullRequests :: ProjectState -> [PullRequestId]
@@ -287,9 +308,11 @@ approvedPullRequests = filterPullRequestsBy $ isJust . approval
 -- before the PR with the given id will be rebased, in case no other pull
 -- requests get approved in the mean time (PRs with a lower id may skip ahead).
 getQueuePosition :: PullRequestId -> ProjectState -> Int
-getQueuePosition pr state =
+getQueuePosition prIndex state =
   let
-    queue = filter (< pr) $ filterPullRequestsBy isQueued state
+    approvalNumber = maybe (maxBound) approvalOrder (lookupPullRequest prIndex state >>= approval)
+    isEarlier pr = isQueued pr && maybe maxBound approvalOrder (approval pr) < approvalNumber
+    queue = filterPullRequestsBy isEarlier state
     inProgress = filterPullRequestsBy isInProgress state
   in
     length (inProgress ++ queue)

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -12,6 +12,7 @@ module WebInterface (renderPage, viewIndex, viewProject, viewOwner, stylesheet, 
 
 import Control.Monad (forM_, unless, void)
 import Crypto.Hash (Digest, SHA256, hash)
+import Data.List (sortOn)
 import Data.Bifunctor (second)
 import Data.ByteArray.Encoding (Base (Base64, Base64URLUnpadded), convertToBase)
 import Data.FileEmbed (embedStringFile)
@@ -155,7 +156,8 @@ viewProjectQueues info state = do
   let approved = filterPrs (== Project.PrStatusApproved)
   unless (null approved) $ do
     h2 "Approved"
-    viewList viewPullRequestWithApproval info approved
+    let approvedSorted = sortOn (\(_, pr, _) -> approvalOrder <$> Project.approval pr) approved
+    viewList viewPullRequestWithApproval info approvedSorted
 
   let awaitingApproval = filterPrs (== Project.PrStatusAwaitingApproval)
   unless (null awaitingApproval) $ do


### PR DESCRIPTION
Fixes #25 

Changes in which order PRs are merged from lowest PR number first to first approved first. 

Every `Approval` gets an index which is used to sort the PRs. The one with the lowest index gets merged first. The index gets assigned once tagged for merge and the global index is incremented. This makes sure that if a PR was approved before another PR, it is also merged first. 

To deploy this change, remove the state `.json` files and let the synchronize step initiate new ones. 