### PR TITLE
Change the wording of the second pull request in line

### DIFF
--- a/locale.nix
+++ b/locale.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import (import ./nixpkgs-pinned.nix) {};
+  pkgs = import ./nixpkgs-pinned.nix {};
 in
   # Needed for the locale-archive.
   pkgs.glibcLocales

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -562,7 +562,7 @@ describeStatus prId pr state = case Pr.classifyPullRequest pr of
       approvalCommand = Pr.displayApproval approvalType
     in case Pr.getQueuePosition prId state of
       0 -> format "Pull request approved for {} by @{}, rebasing now." [approvalCommand, approvedBy]
-      1 -> format "Pull request approved for {} by @{}, waiting for rebase at the front of the queue." [approvalCommand, approvedBy]
+      1 -> format "Pull request approved for {} by @{}, waiting for rebase behind one pull request." [approvalCommand, approvedBy]
       n -> format "Pull request approved for {} by @{}, waiting for rebase behind {} pull requests." (approvalCommand, approvedBy, n)
   PrStatusBuildPending ->
     let Sha sha = fromJust $ getIntegrationSha pr

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -426,7 +426,7 @@ main = hspec $ do
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
+        , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3) "Pull request approved for merge and deploy by @deckard, waiting for rebase behind 2 pull requests."
         ]
@@ -453,7 +453,7 @@ main = hspec $ do
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 3) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
+        , ALeaveComment (PullRequestId 3) "Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase behind 2 pull requests."
         ]
@@ -507,7 +507,7 @@ main = hspec $ do
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "dec") False
         , ALeaveComment (PullRequestId 2) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
+        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3) "Pull request approved for merge by @deckard, waiting for rebase behind 2 pull requests."
         ]
@@ -541,7 +541,7 @@ main = hspec $ do
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase at the front of the queue."
+        , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , ALeaveComment (PullRequestId 1) "Abandoning this pull request because it was closed."
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "dec") False
         , ALeaveComment (PullRequestId 2) "Rebased as b72, waiting for CI …"


### PR DESCRIPTION
The previous wording, "waiting for rebase at the front of the queue",
can be confusing. It is not clear what queue is referred to here. Since
it is unclear whether the queue includes the pull request that is
actively being merged, being "at the front of the queue" can easily be
interpreted as being processed immediately.

This is also more consistent with the `n` pull requests.

<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->
