### PR TITLE
Updated build failed message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build output
 /.stack-work
 /dist
+/dist-newstyle
 /package/*.deb
 
 # Cabal sandbox

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,6 +7,12 @@ agent:
     type: "e1-standard-2"
     os_image: "ubuntu1804"
 
+# If we push a new build to some branch that isn't master, and another build is
+# already running, we cancel it.
+auto_cancel:
+  running:
+    when: "branch != 'master'"
+
 blocks:
   - name: "Build"
     task:

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -70,18 +70,19 @@ eventFromCommentPayload payload =
     -- separate magic comment, rather than editing the approval comment.
     _ -> Nothing
 
-mapCommitStatus :: Github.CommitStatus -> Project.BuildStatus
-mapCommitStatus status = case status of
+mapCommitStatus :: Github.CommitStatus -> Maybe Text.Text -> Project.BuildStatus
+mapCommitStatus status url = case status of
   Github.Pending -> Project.BuildPending
   Github.Success -> Project.BuildSucceeded
-  Github.Failure -> Project.BuildFailed
-  Github.Error   -> Project.BuildFailed
+  Github.Failure -> Project.BuildFailed url
+  Github.Error   -> Project.BuildFailed url
 
 eventFromCommitStatusPayload :: CommitStatusPayload -> Logic.Event
 eventFromCommitStatusPayload payload =
   let sha    = Github.sha    (payload :: CommitStatusPayload)
       status = Github.status (payload :: CommitStatusPayload)
-  in  Logic.BuildStatusChanged sha (mapCommitStatus status)
+      url    = Github.url    (payload :: CommitStatusPayload)
+  in  Logic.BuildStatusChanged sha (mapCommitStatus status url)
 
 convertGithubEvent :: Github.WebhookEvent -> Maybe Logic.Event
 convertGithubEvent event = case event of

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -164,8 +164,8 @@ viewProjectQueues info state = do
     h2 "Awaiting approval"
     viewList viewPullRequest info awaitingApproval
 
-  let failed = filterPrs $ \ st ->
-        (st == Project.PrStatusFailedConflict) || (st == Project.PrStatusFailedBuild)
+  let failed = filterPrs prFailed
+
   unless (null failed) $ do
     h2 "Failed"
     -- TODO: Also render failure reason: conflicted or build failed.
@@ -203,8 +203,8 @@ viewGroupedProjectQueues projects = do
     h2 "Awaiting approval"
     mapM_ (uncurry $ viewList' viewPullRequest) awaitingApproval
 
-  let failed = filterPrs $ \ st ->
-        (st == Project.PrStatusFailedConflict) || (st == Project.PrStatusFailedBuild)
+  let failed = filterPrs prFailed
+
   unless (null failed) $ do
     h2 "Failed"
     -- TODO: Also render failure reason: conflicted or build failed.
@@ -258,3 +258,8 @@ viewList  :: (ProjectInfo -> PullRequestId -> PullRequest -> Html)
           -> [(PullRequestId, PullRequest, status)]
           -> Html
 viewList view info prs = forM_  prs $ \(prId, pr, _) -> p $ view info prId pr
+
+prFailed :: Project.PullRequestStatus -> Bool
+prFailed Project.PrStatusFailedConflict  = True
+prFailed (Project.PrStatusFailedBuild _) = True
+prFailed _                               = False

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -17,7 +17,7 @@ import Data.ByteString.Lazy (readFile)
 import Data.Foldable (foldlM)
 import Data.IntSet (IntSet)
 import Data.Maybe (fromJust, isJust, isNothing)
-import Data.Text (Text)
+import Data.Text (Text, pack)
 import Prelude hiding (readFile)
 import System.Directory (getTemporaryDirectory, removeFile)
 import System.FilePath ((</>))
@@ -968,7 +968,7 @@ main = hspec $ do
         events =
           [ CommentAdded (PullRequestId 1) "deckard" "@bot merge"
           , BuildStatusChanged (Sha "b71") Project.BuildPending
-          , BuildStatusChanged (Sha "b71") Project.BuildFailed
+          , BuildStatusChanged (Sha "b71") $ Project.BuildFailed $ Just $ pack "https://example.com/build-status"
             -- User summons bot again because CI failed for an external reason.
           , CommentAdded (PullRequestId 1) "deckard" "@bot merge"
           ]
@@ -980,11 +980,11 @@ main = hspec $ do
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a39") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
-        , ALeaveComment (PullRequestId 1) "The build failed."
+        , ALeaveComment (PullRequestId 1) "The build failed: https://example.com/build-status\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
         , AIsReviewer "deckard"
           -- Nothing has changed for the bot because b71 has already failed, so
           -- it doesn't retry, but reports the correct state.
-        , ALeaveComment (PullRequestId 1) "The build failed."
+        , ALeaveComment (PullRequestId 1) "The build failed: https://example.com/build-status\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
         ]
 
   describe "Github._Payload" $ do
@@ -1232,13 +1232,13 @@ main = hspec $ do
     it "converts a commit status failure event" $ do
       let payload = testCommitStatusPayload Github.Failure
           Just event = convertGithubEvent $ Github.CommitStatus payload
-      event `shouldBe` (BuildStatusChanged (Sha "b26354") Project.BuildFailed)
+      event `shouldBe` (BuildStatusChanged (Sha "b26354") $ Project.BuildFailed $ Just $ pack "https://travis-ci.org/rachael/owl/builds/1982")
 
     it "converts a commit status error event" $ do
       let payload = testCommitStatusPayload Github.Error
           Just event = convertGithubEvent $ Github.CommitStatus payload
       -- The error and failure statuses are both converted to "failed".
-      event `shouldBe` (BuildStatusChanged (Sha "b26354") Project.BuildFailed)
+      event `shouldBe` (BuildStatusChanged (Sha "b26354") $ Project.BuildFailed $ Just $ pack "https://travis-ci.org/rachael/owl/builds/1982")
 
   describe "ProjectState" $ do
 


### PR DESCRIPTION
Updated the build failed message with an url to the build failure (if provided by github)
This closes #24