### PR TITLE
Refuse merge to non master branch

### DIFF
--- a/src/Github.hs
+++ b/src/Github.hs
@@ -33,7 +33,7 @@ import Data.Aeson.Types (Parser, typeMismatch)
 import Data.Text (Text)
 import GHC.Natural (Natural)
 
-import Git (Sha (..), Branch (..))
+import Git (Sha (..), Branch (..), BaseBranch (..))
 import Project (ProjectInfo (..))
 import Types (Username)
 import Data.Maybe (fromMaybe)
@@ -66,14 +66,15 @@ data CommitStatus
   deriving (Eq, Show)
 
 data PullRequestPayload = PullRequestPayload {
-  action     :: PullRequestAction, -- Corresponds to "action".
-  owner      :: Text,     -- Corresponds to "pull_request.base.repo.owner.login".
-  repository :: Text,     -- Corresponds to "pull_request.base.repo.name".
-  number     :: Int,      -- Corresponds to "pull_request.number".
-  branch     :: Branch,   -- Corresponds to "pull_request.head.ref".
-  sha        :: Sha,      -- Corresponds to "pull_request.head.sha".
-  title      :: Text,     -- Corresponds to "pull_request.title".
-  author     :: Username  -- Corresponds to "pull_request.user.login".
+  action      :: PullRequestAction, -- Corresponds to "action".
+  owner       :: Text,     -- Corresponds to "pull_request.base.repo.owner.login".
+  repository  :: Text,     -- Corresponds to "pull_request.base.repo.name".
+  baseBranch  :: BaseBranch,   -- Corresponds to "pull_request.base.ref"
+  number      :: Int,      -- Corresponds to "pull_request.number".
+  branch      :: Branch,   -- Corresponds to "pull_request.head.ref".
+  sha         :: Sha,      -- Corresponds to "pull_request.head.sha".
+  title       :: Text,     -- Corresponds to "pull_request.title".
+  author      :: Username  -- Corresponds to "pull_request.user.login".
 } deriving (Eq, Show)
 
 data CommentPayload = CommentPayload {
@@ -135,6 +136,7 @@ instance FromJSON PullRequestPayload where
     <$> (v .: "action")
     <*> getNested v ["pull_request", "base", "repo", "owner", "login"]
     <*> getNested v ["pull_request", "base", "repo", "name"]
+    <*> getNested v ["pull_request", "base", "ref"]
     <*> getNested v ["pull_request", "number"]
     <*> getNested v ["pull_request", "head", "ref"]
     <*> getNested v ["pull_request", "head", "sha"]

--- a/src/GithubApi.hs
+++ b/src/GithubApi.hs
@@ -43,7 +43,7 @@ import qualified Network.HTTP.Client as Http
 import qualified Network.HTTP.Types.Status as Http
 
 import Format (format)
-import Git (Branch (..), Sha (..))
+import Git (BaseBranch (..), Branch (..), Sha (..))
 import Project (ProjectInfo)
 import Types (PullRequestId (..), Username (..))
 
@@ -54,6 +54,7 @@ import qualified Project
 data PullRequest = PullRequest
   { sha    :: Sha
   , branch :: Branch
+  , baseBranch :: BaseBranch
   , title  :: Text
   , author :: Username
   }
@@ -150,6 +151,7 @@ runGithub auth projectInfo operation =
         Right details -> pure $ cont $ Just $ PullRequest
           { sha    = Sha $ Github3.pullRequestCommitSha $ Github3.pullRequestHead details
           , branch = Branch $ Github3.pullRequestCommitRef $ Github3.pullRequestHead details
+          , baseBranch = BaseBranch $ Github3.pullRequestCommitRef $ Github3.pullRequestBase details
           , title  = Github3.pullRequestTitle details
           , author = Username $ Github3.untagName $ Github3.simpleUserLogin $ Github3.pullRequestUser details
           }

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -30,7 +30,7 @@ import qualified Data.UUID.V4 as Uuid
 import qualified System.Directory as FileSystem
 
 import Configuration (ProjectConfiguration, TriggerConfiguration, UserConfiguration)
-import Git (Branch (..), RefSpec (refSpec), Sha (..))
+import Git (BaseBranch (..), Branch (..), RefSpec (refSpec), Sha (..))
 import GithubApi (GithubOperationFree)
 import Project (BuildStatus (..), IntegrationStatus (..), ProjectState, PullRequestId (..))
 
@@ -42,6 +42,9 @@ import qualified GithubApi
 import qualified Logic
 import qualified Prelude
 import qualified Project
+
+masterBranch :: BaseBranch
+masterBranch = BaseBranch "master"
 
 -- Invokes Git with the given arguments, returns its stdout. Crashes if invoking
 -- Git failed. Discards all logging.
@@ -330,13 +333,14 @@ eventLoopSpec = parallel $ do
           -- Note that at the remote, refs/pull/4/head points to c4.
           pr4 = PullRequestId 4
           branch = Branch "ahead"
+          baseBranch = masterBranch
 
         -- Commit c4 is one commit ahead of master, so integrating it can be done
         -- with a fast-forward merge. Run the main event loop for these events
         -- and discard the final state by using 'void'.
         void $ runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr4 branch c4 "Add Leon test results" "deckard",
+            Logic.PullRequestOpened pr4 branch baseBranch c4 "Add Leon test results" "deckard",
             Logic.CommentAdded pr4 "rachael" "@bot merge",
             Logic.BuildStatusChanged c4 BuildSucceeded
           ]
@@ -359,12 +363,13 @@ eventLoopSpec = parallel $ do
           [_c0, _c1, _c2, _c3, _c3', c4, _c5, _c6, _c7, _c7f, _c8] = shas
           pr4 = PullRequestId 4
           branch = Branch "ahead"
+          baseBranch = masterBranch
 
         -- Commit c4 is one commit ahead of master, so integrating it can be done
         -- with a fast-forward merge. A new tag `v2` should appear
         void $ runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr4 branch c4 "Deploy tests!" "deckard",
+            Logic.PullRequestOpened pr4 branch baseBranch c4 "Deploy tests!" "deckard",
             Logic.CommentAdded pr4 "rachael" "@bot merge and tag",
             Logic.BuildStatusChanged c4 BuildSucceeded
           ]
@@ -386,12 +391,13 @@ eventLoopSpec = parallel $ do
             -- Note that at the remote, refs/pull/6/head points to c6.
             pr6 = PullRequestId 6
             branch = Branch "intro"
+            baseBranch = masterBranch
 
         -- Commit c6 is two commits ahead and one behind of master, so
         -- integrating it produces new rebased commits.
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr6 branch c6 "Add Leon test results" "deckard",
+            Logic.PullRequestOpened pr6 branch baseBranch c6 "Add Leon test results" "deckard",
             Logic.CommentAdded pr6 "rachael" "@bot merge"
           ]
 
@@ -427,12 +433,13 @@ eventLoopSpec = parallel $ do
         let [_c0, _c1, _c2, _c3, _c3', _c4, _c5, c6, _c7, _c7f, _c8] = shas
             pr6 = PullRequestId 6
             branch = Branch "intro"
+            baseBranch = masterBranch
 
         -- Commit c6 is two commits ahead and one behind of master, so
         -- integrating it produces new rebased commits.
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr6 branch c6 "Deploy it now!" "deckard",
+            Logic.PullRequestOpened pr6 branch baseBranch c6 "Deploy it now!" "deckard",
             Logic.CommentAdded pr6 "rachael" "@bot merge and tag"
           ]
 
@@ -465,11 +472,12 @@ eventLoopSpec = parallel $ do
             pr6 = PullRequestId 6
             br4 = Branch "ahead"
             br6 = Branch "intro"
+            baseBranch = masterBranch
 
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr4 br4 c4 "Add Leon test results" "deckard",
-            Logic.PullRequestOpened pr6 br6 c6 "Add Rachael test results" "deckard",
+            Logic.PullRequestOpened pr4 br4 baseBranch c4 "Add Leon test results" "deckard",
+            Logic.PullRequestOpened pr6 br6 baseBranch c6 "Add Rachael test results" "deckard",
             -- Note that although c4 has a lower pull request number, c6 should
             -- still be integrated first because it was approved earlier.
             Logic.CommentAdded pr6 "rachael" "@bot merge",
@@ -512,11 +520,12 @@ eventLoopSpec = parallel $ do
             pr6 = PullRequestId 6
             br4 = Branch "ahead"
             br6 = Branch "intro"
+            baseBranch = masterBranch
 
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr4 br4 c4 "Add Leon test results" "deckard",
-            Logic.PullRequestOpened pr6 br6 c6 "Add Rachael test results" "deckard",
+            Logic.PullRequestOpened pr4 br4 baseBranch c4 "Add Leon test results" "deckard",
+            Logic.PullRequestOpened pr6 br6 baseBranch c6 "Add Rachael test results" "deckard",
             Logic.CommentAdded pr6 "rachael" "@bot merge and tag",
             Logic.CommentAdded pr4 "rachael" "@bot merge and tag"
           ]
@@ -558,13 +567,14 @@ eventLoopSpec = parallel $ do
             pr4 = PullRequestId 4
             br3 = Branch "alternative"
             br4 = Branch "ahead"
+            baseBranch = masterBranch
 
         -- Commit c3' conflicts with master, so a rebase should be attempted, but
         -- because it conflicts, the next pull request should be considered.
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr3 br3 c3' "Add Leon test results" "deckard",
-            Logic.PullRequestOpened pr4 br4 c4 "Add Rachael test results" "deckard",
+            Logic.PullRequestOpened pr3 br3 baseBranch c3' "Add Leon test results" "deckard",
+            Logic.PullRequestOpened pr4 br4 baseBranch c4 "Add Rachael test results" "deckard",
             Logic.CommentAdded pr3 "rachael" "@bot merge",
             Logic.CommentAdded pr4 "rachael" "@bot merge"
           ]
@@ -574,7 +584,7 @@ eventLoopSpec = parallel $ do
         -- the conflicted rebase, so that the next commit can be integrated
         -- properly.
         let Just pullRequest3 = Project.lookupPullRequest pr3 state
-        Project.integrationStatus pullRequest3 `shouldBe` Conflicted (Branch "master")
+        Project.integrationStatus pullRequest3 `shouldBe` Conflicted (masterBranch)
 
         -- The second pull request should still be pending, awaiting the build
         -- result.
@@ -600,10 +610,11 @@ eventLoopSpec = parallel $ do
           [_c0, _c1, _c2, _c3, _c3', c4, _c5, c6, _c7, _c7f, _c8] = shas
           pr6 = PullRequestId 6
           branch = Branch "intro"
+          baseBranch = masterBranch
 
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr6 branch c6 "Add test results" "deckard",
+            Logic.PullRequestOpened pr6 branch baseBranch c6 "Add test results" "deckard",
             Logic.CommentAdded pr6 "rachael" "@bot merge"
           ]
 
@@ -612,7 +623,7 @@ eventLoopSpec = parallel $ do
         -- to the origin "master" branch, so that pushing the rebased c6 will
         -- fail later on.
         git ["fetch", "origin", "ahead"] -- The ref for commit c4.
-        git ["push", "origin", refSpec (c4, Branch "master")]
+        git ["push", "origin", refSpec (c4, masterBranch)]
 
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
@@ -656,10 +667,11 @@ eventLoopSpec = parallel $ do
           [_c0, _c1, _c2, _c3, _c3', c4, _c5, c6, _c7, _c7f, _c8] = shas
           pr6 = PullRequestId 6
           branch = Branch "intro"
+          baseBranch = masterBranch
 
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr6 branch c6 "Add test results" "deckard",
+            Logic.PullRequestOpened pr6 branch baseBranch c6 "Add test results" "deckard",
             Logic.CommentAdded pr6 "rachael" "@bot merge and tag"
           ]
 
@@ -668,7 +680,7 @@ eventLoopSpec = parallel $ do
         -- to the origin "master" branch, so that pushing the rebased c6 will
         -- fail later on.
         git ["fetch", "origin", "ahead"] -- The ref for commit c4.
-        git ["push", "origin", refSpec (c4, Branch "master")]
+        git ["push", "origin", refSpec (c4, masterBranch)]
 
         let
           Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
@@ -706,10 +718,11 @@ eventLoopSpec = parallel $ do
           [_c0, _c1, _c2, _c3, _c3', c4, _c5, c6, _c7, _c7f, _c8] = shas
           pr6 = PullRequestId 6
           branch = Branch "intro"
+          baseBranch = masterBranch
 
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr6 branch c6 "Add test results" "deckard",
+            Logic.PullRequestOpened pr6 branch baseBranch c6 "Add test results" "deckard",
             Logic.CommentAdded pr6 "rachael" "@bot merge and tag"
           ]
 
@@ -717,7 +730,7 @@ eventLoopSpec = parallel $ do
         -- Before we notify build success, push commmit c4 and a new tag to the origin "master"
         -- branch, so that pushing the rebased c6 will fail later on.
         git ["fetch", "origin", "ahead"] -- The ref for commit c4.
-        git ["push", "origin", refSpec (c4, Branch "master")]
+        git ["push", "origin", refSpec (c4, masterBranch)]
         git ["tag", "-a", "v2", "-m", "v2", refSpec c4]
         git ["push", "origin", refSpec (Git.TagName "v2")]
 
@@ -758,10 +771,11 @@ eventLoopSpec = parallel $ do
           [_c0, _c1, _c2, _c3, _c3', _c4, _c5, _c6, _c7, c7f, _c8] = shas
           pr8 = PullRequestId 8
           branch = Branch "fixup"
+          baseBranch = masterBranch
 
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr8 branch c7f "Add test results" "deckard",
+            Logic.PullRequestOpened pr8 branch baseBranch c7f "Add test results" "deckard",
             Logic.CommentAdded pr8 "rachael" "@bot merge"
           ]
 
@@ -796,15 +810,16 @@ eventLoopSpec = parallel $ do
           [_c0, _c1, _c2, _c3, _c3', c4, _c5, _c6, _c7, c7f, _c8] = shas
           pr8 = PullRequestId 8
           branch = Branch "fixup"
+          baseBranch = masterBranch
 
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr8 branch c7f "Add test results" "deckard",
+            Logic.PullRequestOpened pr8 branch baseBranch c7f "Add test results" "deckard",
             Logic.CommentAdded pr8 "rachael" "@bot merge"
           ]
 
         git ["fetch", "origin", "ahead"] -- The ref for commit c4.
-        git ["push", "origin", refSpec (c4, Branch "master")]
+        git ["push", "origin", refSpec (c4, masterBranch)]
 
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
@@ -843,6 +858,7 @@ eventLoopSpec = parallel $ do
           [_c0, _c1, _c2, _c3, _c3', _c4, _c5, _c6, _c7, c7f, c8] = shas
           pr8 = PullRequestId 8
           branch = Branch "fixup"
+          baseBranch = masterBranch
 
         -- The commit graph looks like "c7 -- c8 -- c7f", where c7 needs to be
         -- fixed up. We now already push c8 to master, so the only thing left in
@@ -850,11 +866,11 @@ eventLoopSpec = parallel $ do
         -- the bad commit c7 is already on master. Note that origin/master is
         -- not a parent of c8, so we force-push.
         git ["fetch", "origin", "fixup"] -- The ref for commit c7f.
-        git ["push", "--force", "origin", refSpec (c8, Branch "master")]
+        git ["push", "--force", "origin", refSpec (c8, masterBranch)]
 
         state <- runLoop Project.emptyProjectState
           [
-            Logic.PullRequestOpened pr8 branch c7f "Add test results" "deckard",
+            Logic.PullRequestOpened pr8 branch baseBranch c7f "Add test results" "deckard",
             Logic.CommentAdded pr8 "rachael" "@bot merge"
           ]
 

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -29,7 +29,7 @@ import qualified Data.IntSet as IntSet
 import qualified Data.UUID.V4 as Uuid
 
 import EventLoop (convertGithubEvent)
-import Git (Branch (..), PushResult (..), Sha (..), TagName (TagName))
+import Git (BaseBranch (..), Branch (..), PushResult (..), Sha (..), TagName (TagName))
 import Github (CommentPayload, CommitStatusPayload, PullRequestPayload)
 import Logic (Action, ActionFree (..), Event (..), IntegrationFailure (..))
 import Project (Approval (..), ProjectState (ProjectState), PullRequest (PullRequest))
@@ -41,28 +41,41 @@ import qualified GithubApi
 import qualified Logic
 import qualified Project
 
+masterBranch :: BaseBranch
+masterBranch = BaseBranch "master"
+
 -- Trigger config used throughout these tests.
 testTriggerConfig :: Config.TriggerConfiguration
 testTriggerConfig = Config.TriggerConfiguration {
   Config.commentPrefix = "@bot"
 }
 
+testProjectConfig :: Config.ProjectConfiguration
+testProjectConfig = Config.ProjectConfiguration {
+  Config.owner = "peter",
+  Config.repository = "rep",
+  Config.branch = "master",
+  Config.testBranch = "testing",
+  Config.checkout = "/var/lib/hoff/checkouts/peter/rep",
+  Config.stateFile = "/var/lib/hoff/state/peter/rep.json"
+}
+
 -- Functions to prepare certain test states.
 
-singlePullRequestState :: PullRequestId -> Branch -> Sha -> Username -> ProjectState
-singlePullRequestState pr prBranch prSha prAuthor =
+singlePullRequestState :: PullRequestId -> Branch -> BaseBranch -> Sha -> Username -> ProjectState
+singlePullRequestState pr prBranch baseBranch prSha prAuthor =
   let
-    event = PullRequestOpened pr prBranch prSha "Untitled" prAuthor
+    event = PullRequestOpened pr prBranch baseBranch prSha "Untitled" prAuthor
   in
     fst $ runAction $ handleEventTest event Project.emptyProjectState
 
-candidateState :: PullRequestId -> Branch -> Sha -> Username -> Username -> Sha -> ProjectState
-candidateState pr prBranch prSha prAuthor approvedBy candidateSha =
+candidateState :: PullRequestId -> Branch -> BaseBranch -> Sha -> Username -> Username -> Sha -> ProjectState
+candidateState pr prBranch baseBranch prSha prAuthor approvedBy candidateSha =
   let
     state = Project.setIntegrationStatus pr
       (Project.Integrated candidateSha Project.BuildPending)
       $ Project.setApproval pr (Just (Approval approvedBy Project.Merge 0))
-      $ singlePullRequestState pr prBranch prSha prAuthor
+      $ singlePullRequestState pr prBranch baseBranch prSha prAuthor
   in
     state { Project.integrationCandidate = Just pr }
 
@@ -95,7 +108,7 @@ data Results = Results
 defaultResults :: Results
 defaultResults = Results
     -- Pretend that integration always conflicts.
-  { resultIntegrate = repeat $ Left $ Logic.IntegrationFailure $ Branch "master"
+  { resultIntegrate = repeat $ Left $ Logic.IntegrationFailure $ BaseBranch "master"
     -- Pretend that pushing is always successful.
   , resultPush = repeat PushOk
     -- Pretend that these two calls to GitHub always fail.
@@ -201,19 +214,19 @@ runAction = runActionCustom defaultResults
 -- Handle an event, then advance the state until a fixed point,
 -- and simulate its side effects.
 handleEventTest :: Event -> ProjectState -> Action ProjectState
-handleEventTest = Logic.handleEvent testTriggerConfig
+handleEventTest = Logic.handleEvent testTriggerConfig testProjectConfig
 
 -- Handle events (advancing the state until a fixed point in between) and
 -- simulate their side effects.
 handleEventsTest :: [Event] -> ProjectState -> Action ProjectState
-handleEventsTest events state = foldlM (flip $ Logic.handleEvent testTriggerConfig) state events
+handleEventsTest events state = foldlM (flip $ Logic.handleEvent testTriggerConfig testProjectConfig) state events
 
 main :: IO ()
 main = hspec $ do
   describe "Logic.handleEvent" $ do
 
     it "handles PullRequestOpened" $ do
-      let event = PullRequestOpened (PullRequestId 3) (Branch "p") (Sha "e0f") "title" "lisa"
+      let event = PullRequestOpened (PullRequestId 3) (Branch "p") masterBranch (Sha "e0f") "title" "lisa"
           state = fst $ runAction $ handleEventTest event Project.emptyProjectState
       state `shouldSatisfy` Project.existsPullRequest (PullRequestId 3)
       let pr = fromJust $ Project.lookupPullRequest (PullRequestId 3) state
@@ -223,35 +236,36 @@ main = hspec $ do
       Project.integrationStatus pr `shouldBe` Project.NotIntegrated
 
     it "handles PullRequestClosed" $ do
-      let event1 = PullRequestOpened (PullRequestId 1) (Branch "p") (Sha "abc") "title" "peter"
-          event2 = PullRequestOpened (PullRequestId 2) (Branch "q") (Sha "def") "title" "jack"
+      let event1 = PullRequestOpened (PullRequestId 1) (Branch "p") masterBranch (Sha "abc") "title" "peter"
+          event2 = PullRequestOpened (PullRequestId 2) (Branch "q") masterBranch (Sha "def") "title" "jack"
           event3 = PullRequestClosed (PullRequestId 1)
           state  = fst $ runAction $ handleEventsTest [event1, event2, event3] Project.emptyProjectState
       state `shouldSatisfy` not . Project.existsPullRequest (PullRequestId 1)
       state `shouldSatisfy` Project.existsPullRequest (PullRequestId 2)
 
     it "handles PullRequestEdited" $ do
-      let event1 = PullRequestOpened (PullRequestId 1) (Branch "p") (Sha "abc") "title" "peter"
-          event2 = PullRequestEdited (PullRequestId 1) "newTitle"
+      let event1 = PullRequestOpened (PullRequestId 1) (Branch "p") (BaseBranch "m") (Sha "abc") "title" "peter"
+          event2 = PullRequestEdited (PullRequestId 1) "newTitle" masterBranch
           state = fst $ runAction $ handleEventsTest [event1, event2] Project.emptyProjectState
           pr = fromJust $ Project.lookupPullRequest (PullRequestId 1) state
-      Project.title pr `shouldBe` "newTitle"
+      Project.title pr      `shouldBe` "newTitle"
+      Project.baseBranch pr `shouldBe` masterBranch
 
     it "handles closing the integration candidate PR" $ do
       let event  = PullRequestClosed (PullRequestId 1)
-          state  = candidateState (PullRequestId 1) (Branch "p") (Sha "ea0") "frank" "deckard" (Sha "cf4")
+          state  = candidateState (PullRequestId 1) (Branch "p") masterBranch (Sha "ea0") "frank" "deckard" (Sha "cf4")
           state' = fst $ runAction $ handleEventTest event state
       Project.integrationCandidate state' `shouldBe` Nothing
 
     it "does not modify the integration candidate if a different PR was closed" $ do
       let event  = PullRequestClosed (PullRequestId 1)
-          state  = candidateState (PullRequestId 2) (Branch "p") (Sha "a38") "franz" "deckard" (Sha "ed0")
+          state  = candidateState (PullRequestId 2) (Branch "p") masterBranch (Sha "a38") "franz" "deckard" (Sha "ed0")
           state' = fst $ runAction $ handleEventTest event state
       Project.integrationCandidate state' `shouldBe` (Just $ PullRequestId 2)
 
     it "loses approval after the PR commit has changed" $ do
       let event  = PullRequestCommitChanged (PullRequestId 1) (Sha "def")
-          state0 = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "abc") "alice"
+          state0 = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "abc") "alice"
           state1 = Project.setApproval (PullRequestId 1) (Just (Approval "hatter" Project.Merge 0)) state0
           state2 = fst $ runAction $ handleEventTest event state1
           pr1    = fromJust $ Project.lookupPullRequest (PullRequestId 1) state1
@@ -261,7 +275,7 @@ main = hspec $ do
 
     it "does not lose approval after the PR commit has changed due to a push we caused" $ do
       let
-        state0 = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "abc") "alice"
+        state0 = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "abc") "alice"
         state1 = Project.setApproval (PullRequestId 1) (Just (Approval "hatter" Project.Merge 0)) state0
         state2 = Project.setIntegrationStatus (PullRequestId 1) (Project.Integrated (Sha "dc0") Project.BuildPending) state1
         state3 = Project.setIntegrationStatus (PullRequestId 1) (Project.Integrated (Sha "dc1") Project.BuildPending) state2
@@ -277,7 +291,7 @@ main = hspec $ do
 
     it "resets the approval, integration, and build status after the PR commit has changed" $ do
       let
-        state1  = candidateState (PullRequestId 1) (Branch "p") (Sha "abc") "thomas" "deckard" (Sha "bcd")
+        state1  = candidateState (PullRequestId 1) (Branch "p") masterBranch (Sha "abc") "thomas" "deckard" (Sha "bcd")
         newPush = PullRequestCommitChanged (PullRequestId 1) (Sha "def")
         state2  = fst $ runAction $ handleEventTest newPush state1
         prAt1   = fromJust $ Project.lookupPullRequest (PullRequestId 1) state1
@@ -292,7 +306,7 @@ main = hspec $ do
         -- This commit change is not really a change, therefore we should not
         -- lose the approval status.
         event  = PullRequestCommitChanged (PullRequestId 1) (Sha "000")
-        state0 = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "000") "cindy"
+        state0 = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "000") "cindy"
         state1 = Project.setApproval (PullRequestId 1) (Just (Approval "daniel" Project.Merge 0)) state0
         (state2, _actions) = runAction $ Logic.proceedUntilFixedPoint state1
         (state3, actions)  = runAction $ handleEventTest event state2
@@ -302,7 +316,7 @@ main = hspec $ do
       Project.approval prAt3 `shouldBe` Just (Approval "daniel" Project.Merge 0)
 
     it "sets approval after a stamp from a reviewer" $ do
-      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "6412ef5") "toby"
+      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "toby"
           -- Note: "deckard" is marked as reviewer in the test config.
           event  = CommentAdded (PullRequestId 1) "deckard" "@bot merge"
           state' = fst $ runAction $ handleEventTest event state
@@ -310,7 +324,7 @@ main = hspec $ do
       Project.approval pr `shouldBe` Just (Approval "deckard" Project.Merge 0)
 
     it "does not set approval after a stamp from a non-reviewer" $ do
-      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "6412ef5") "toby"
+      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "toby"
           -- Note: the comment is a valid approval command, but "rachael" is not
           -- marked as reviewer in the test config.
           event  = CommentAdded (PullRequestId 1) "rachael" "@bot merge"
@@ -319,7 +333,7 @@ main = hspec $ do
       Project.approval pr `shouldBe` Nothing
 
     it "does not set approval after a comment with the wrong prefix" $ do
-      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "6412ef5") "patrick"
+      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "patrick"
           -- Note: "deckard" is marked as reviewer in the test config, but the
           -- prefix is "@bot ", so none of the comments below should trigger approval.
           event1 = CommentAdded (PullRequestId 1) "deckard" "@hoffbot merge"
@@ -333,7 +347,7 @@ main = hspec $ do
       Project.approval pr `shouldBe` Nothing
 
     it "accepts command comments case-insensitively" $ do
-      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "6412ef5") "sacha"
+      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "sacha"
           -- Note: "deckard" is marked as reviewer in the test config.
           event  = CommentAdded (PullRequestId 1) "deckard" "@BoT MeRgE"
           state' = fst $ runAction $ handleEventTest event state
@@ -341,7 +355,7 @@ main = hspec $ do
       Project.approval pr `shouldBe` Just (Approval "deckard" Project.Merge 0)
 
     it "accepts command at end of other comments" $ do
-      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "6412ef5") "sacha"
+      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "sacha"
           -- Note: "deckard" is marked as reviewer in the test config.
           event  = CommentAdded (PullRequestId 1) "deckard" "looks good to me, @bot merge"
           state' = fst $ runAction $ handleEventTest event state
@@ -349,7 +363,7 @@ main = hspec $ do
       Project.approval pr `shouldBe` Just (Approval "deckard" Project.Merge 0)
 
     it "accepts command at end of other comments if tagged multiple times" $ do
-      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "6412ef5") "sacha"
+      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "sacha"
           -- Note: "deckard" is marked as reviewer in the test config.
           event  = CommentAdded (PullRequestId 1) "deckard" "@bot looks good to me, @bot merge"
           state' = fst $ runAction $ handleEventTest event state
@@ -357,7 +371,7 @@ main = hspec $ do
       Project.approval pr `shouldBe` Just (Approval "deckard" Project.Merge 0)
 
     it "accepts command before comments" $ do
-      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "6412ef5") "sacha"
+      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "sacha"
           -- Note: "deckard" is marked as reviewer in the test config.
           event  = CommentAdded (PullRequestId 1) "deckard" "@bot merge\nYou did some fine work here."
           state' = fst $ runAction $ handleEventTest event state
@@ -365,7 +379,7 @@ main = hspec $ do
       Project.approval pr `shouldBe` Just (Approval "deckard" Project.Merge 0)
 
     it "does not accepts merge command with interleaved comments" $ do
-      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "6412ef5") "sacha"
+      let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "sacha"
           -- Note: "deckard" is marked as reviewer in the test config.
           event  = CommentAdded (PullRequestId 1) "deckard" "@bot foo merge"
           state' = fst $ runAction $ handleEventTest event state
@@ -375,16 +389,16 @@ main = hspec $ do
     it "handles a build status change of the integration candidate" $ do
       let
         event  = BuildStatusChanged (Sha "84c") Project.BuildSucceeded
-        state  = candidateState (PullRequestId 1) (Branch "p") (Sha "a38") "johanna" "deckard" (Sha "84c")
+        state  = candidateState (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "johanna" "deckard" (Sha "84c")
         state' = fst $ runAction $ handleEventTest event state
         pr     = fromJust $ Project.lookupPullRequest (PullRequestId 1) state'
       Project.integrationStatus pr `shouldBe` Project.Integrated (Sha "84c") Project.BuildSucceeded
 
     it "ignores a build status change for commits that are not the integration candidate" $ do
       let
-        event0 = PullRequestOpened (PullRequestId 2) (Branch "p") (Sha "0ad") "title" "harry"
+        event0 = PullRequestOpened (PullRequestId 2) (Branch "p") masterBranch (Sha "0ad") "title" "harry"
         event1 = BuildStatusChanged (Sha "0ad") Project.BuildSucceeded
-        state  = candidateState (PullRequestId 1) (Branch "p") (Sha "a38") "harry" "deckard" (Sha "84c")
+        state  = candidateState (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "harry" "deckard" (Sha "84c")
         state' = fst $ runAction $ handleEventsTest [event0, event1] state
         pr1    = fromJust $ Project.lookupPullRequest (PullRequestId 1) state'
         pr2    = fromJust $ Project.lookupPullRequest (PullRequestId 2) state'
@@ -395,7 +409,7 @@ main = hspec $ do
 
     it "only checks if a comment author is a reviewer for comment commands" $ do
       let
-        state = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "a38") "tyrell"
+        state = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "tyrell"
         event0 = CommentAdded (PullRequestId 1) "deckard" "I don't get it, Tyrell"
         event1 = CommentAdded (PullRequestId 1) "deckard" "@bot merge"
         actions0 = snd $ runAction $ handleEventTest event0 state
@@ -413,9 +427,9 @@ main = hspec $ do
     it "notifies approvers about queue position" $ do
       let
         state
-          = Project.insertPullRequest (PullRequestId 1) (Branch "p") (Sha "a38") "Add Nexus 7 experiment" (Username "tyrell")
-          $ Project.insertPullRequest (PullRequestId 2) (Branch "s") (Sha "dec") "Some PR" (Username "rachael")
-          $ Project.insertPullRequest (PullRequestId 3) (Branch "s") (Sha "f16") "Another PR" (Username "rachael")
+          = Project.insertPullRequest (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "Add Nexus 7 experiment" (Username "tyrell")
+          $ Project.insertPullRequest (PullRequestId 2) (Branch "s") masterBranch (Sha "dec") "Some PR" (Username "rachael")
+          $ Project.insertPullRequest (PullRequestId 3) (Branch "s") masterBranch (Sha "f16") "Another PR" (Username "rachael")
           $ Project.emptyProjectState
         -- Approve pull request in order of ascending id, mark the last PR for deployment.
         events =
@@ -440,9 +454,9 @@ main = hspec $ do
     it "keeps the order position for the comments" $ do
       let
         state
-          = Project.insertPullRequest (PullRequestId 1) (Branch "p") (Sha "a38") "Add Nexus 7 experiment" (Username "tyrell")
-          $ Project.insertPullRequest (PullRequestId 2) (Branch "s") (Sha "dec") "Some PR" (Username "rachael")
-          $ Project.insertPullRequest (PullRequestId 3) (Branch "s") (Sha "f16") "Another PR" (Username "rachael")
+          = Project.insertPullRequest (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "Add Nexus 7 experiment" (Username "tyrell")
+          $ Project.insertPullRequest (PullRequestId 2) (Branch "s") masterBranch (Sha "dec") "Some PR" (Username "rachael")
+          $ Project.insertPullRequest (PullRequestId 3) (Branch "s") masterBranch (Sha "f16") "Another PR" (Username "rachael")
           $ Project.emptyProjectState
         -- Approve pull request in order of ascending id, mark the last PR for deployment.
         events =
@@ -470,6 +484,7 @@ main = hspec $ do
           [ (1, PullRequest {
             sha = Sha "a38",
             branch = Branch "p",
+            baseBranch = BaseBranch "master",
             title = "Add Nexus 7 experiment",
             author = Username "tyrell",
             approval = Just (Approval (Username "deckard") Project.Merge 0),
@@ -480,6 +495,7 @@ main = hspec $ do
           , (2, PullRequest {
             sha = Sha "dec",
             branch = Branch "s",
+            baseBranch = BaseBranch "master",
             title = "Some PR",
             author = Username "rachael",
             approval = Just (Approval (Username "deckard") Project.Merge 2),
@@ -490,6 +506,7 @@ main = hspec $ do
           , (3, PullRequest {
             sha = Sha "f16",
             branch = Branch "s",
+            baseBranch = BaseBranch "master",
             title = "Another PR",
             author = Username "rachael",
             approval = Just (Approval (Username "deckard") Project.Merge 1),
@@ -522,8 +539,8 @@ main = hspec $ do
     it "abandons integration when a pull request is closed" $ do
       let
         state
-          = Project.insertPullRequest (PullRequestId 1) (Branch "p") (Sha "a38") "Add Nexus 7 experiment" (Username "tyrell")
-          $ Project.insertPullRequest (PullRequestId 2) (Branch "s") (Sha "dec") "Some PR" (Username "rachael")
+          = Project.insertPullRequest (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "Add Nexus 7 experiment" (Username "tyrell")
+          $ Project.insertPullRequest (PullRequestId 2) (Branch "s") masterBranch (Sha "dec") "Some PR" (Username "rachael")
           $ Project.emptyProjectState
         -- Approve both pull requests, then close the first.
         events =
@@ -566,7 +583,7 @@ main = hspec $ do
 
     it "checks whether pull requests are still open on synchronize" $ do
       let
-        state = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "b7332ba") "tyrell"
+        state = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "b7332ba") "tyrell"
         results = defaultResults
           { resultGetOpenPullRequests = [Just $ IntSet.singleton 1]
           }
@@ -578,7 +595,7 @@ main = hspec $ do
 
     it "closes pull requests that are no longer open on synchronize" $ do
       let
-        state = singlePullRequestState (PullRequestId 10) (Branch "p") (Sha "b7332ba") "tyrell"
+        state = singlePullRequestState (PullRequestId 10) (Branch "p") masterBranch (Sha "b7332ba") "tyrell"
         results = defaultResults
           { resultGetOpenPullRequests = [Just $ IntSet.empty]
           }
@@ -590,7 +607,7 @@ main = hspec $ do
 
     it "does not modify the state on an error during synchronize" $ do
       let
-        state = singlePullRequestState (PullRequestId 19) (Branch "p") (Sha "b7332ba") "tyrell"
+        state = singlePullRequestState (PullRequestId 19) (Branch "p") masterBranch (Sha "b7332ba") "tyrell"
         -- Set up some custom results where we simulate that the GitHub API fails.
         results = defaultResults
           { resultGetOpenPullRequests = [Nothing]
@@ -607,10 +624,11 @@ main = hspec $ do
           { resultGetOpenPullRequests = [Just $ IntSet.singleton 17]
           , resultGetPullRequest =
             [ Just $ GithubApi.PullRequest
-              { GithubApi.sha    = Sha "7faa52318"
-              , GithubApi.branch = Branch "nexus-7"
-              , GithubApi.title  = "Add Nexus 7 experiment"
-              , GithubApi.author = Username "tyrell"
+              { GithubApi.sha        = Sha "7faa52318"
+              , GithubApi.branch     = Branch "nexus-7"
+              , GithubApi.baseBranch = masterBranch
+              , GithubApi.title      = "Add Nexus 7 experiment"
+              , GithubApi.author     = Username "tyrell"
               }
             ]
           }
@@ -632,7 +650,7 @@ main = hspec $ do
 
     it "does not query details of existing pull requests on synchronize" $ do
       let
-        state = singlePullRequestState (PullRequestId 19) (Branch "p") (Sha "b7332ba") "tyrell"
+        state = singlePullRequestState (PullRequestId 19) (Branch "p") masterBranch (Sha "b7332ba") "tyrell"
         results = defaultResults
           { resultGetOpenPullRequests = [Just $ IntSet.singleton 19]
           }
@@ -646,7 +664,7 @@ main = hspec $ do
     it "recognizes 'merge and deploy' commands as the proper ApprovedFor value" $ do
       let
         prId = PullRequestId 1
-        state = singlePullRequestState prId (Branch "p") (Sha "abc1234") "tyrell"
+        state = singlePullRequestState prId (Branch "p") masterBranch (Sha "abc1234") "tyrell"
 
         event = CommentAdded prId "deckard" "@bot merge and deploy"
 
@@ -666,7 +684,7 @@ main = hspec $ do
     it "recognizes 'merge and tag' command" $ do
       let
         prId = PullRequestId 1
-        state = singlePullRequestState prId (Branch "p") (Sha "abc1234") "tyrell"
+        state = singlePullRequestState prId (Branch "p") masterBranch (Sha "abc1234") "tyrell"
 
         event = CommentAdded prId "deckard" "@bot merge and tag"
 
@@ -682,6 +700,64 @@ main = hspec $ do
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
         (\pr -> Project.approval pr == Just (Approval (Username "deckard") Project.MergeAndTag 0))
+    
+    it "rejects 'merge' commands to a branch other than master" $ do
+      let
+        prId = PullRequestId 1
+        state = singlePullRequestState prId (Branch "p") (BaseBranch "m") (Sha "abc1234") "tyrell"
+
+        event = CommentAdded prId "deckard" "@bot merge"
+
+        (state', actions) = runAction $ handleEventTest event state
+
+      actions `shouldBe`
+        [ AIsReviewer "deckard"
+        , ALeaveComment prId "Merge rejected: the target branch must be the integration branch."
+        ]
+
+      fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
+        (\pr -> Project.integrationStatus pr == Project.IncorrectBaseBranch)
+
+    it "doesn't reject 'merge' after a base branch change" $ do
+      let 
+        prId = PullRequestId 1
+        state = singlePullRequestState prId (Branch "p") (BaseBranch "m") (Sha "abc1234") "tyrell"
+        
+        events = 
+          [ CommentAdded prId "deckard" "@bot merge"
+          , PullRequestEdited prId "Untitled" masterBranch
+          , CommentAdded prId "deckard" "@bot merge"] 
+
+        results = defaultResults { resultIntegrate = [Right (Sha "def2345")] }
+        (state', actions) = runActionCustom results $ handleEventsTest events state
+
+      actions `shouldBe` 
+        [ AIsReviewer (Username "deckard")
+        , ALeaveComment (PullRequestId 1) "Merge rejected: the target branch must be the integration branch."
+        , AIsReviewer (Username "deckard")
+        , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ALeaveComment (PullRequestId 1) "Rebased as def2345, waiting for CI \8230"
+        ]
+      
+      fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
+        (\pr -> Project.integrationStatus pr == Project.Integrated (Sha "def2345") Project.BuildPending)
+
+    it "loses approval after an invalid base branch change" $ do
+      let 
+        prId = PullRequestId 1
+        state = singlePullRequestState prId (Branch "p") masterBranch (Sha "abc1234") "tyrell"
+        
+        events = 
+          [ CommentAdded prId "deckard" "@bot merge"
+          , PullRequestEdited prId "Untitled" (BaseBranch "m")
+          ] 
+
+        (state', _) = runAction $ handleEventsTest events state
+        pr = fromJust $ Project.lookupPullRequest (PullRequestId 1) state'
+
+      Project.approval pr `shouldBe` Nothing
+      Project.integrationCandidate state' `shouldBe` Nothing
 
   describe "Logic.proceedUntilFixedPoint" $ do
 
@@ -689,7 +765,7 @@ main = hspec $ do
       let
         state
           = Project.setApproval (PullRequestId 1) (Just (Approval "fred" Project.Merge 0))
-          $ singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "f34") "sally"
+          $ singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "f34") "sally"
         results = defaultResults
           { resultIntegrate = [Right (Sha "38c")]
           , resultPush = [PushRejected]
@@ -708,8 +784,8 @@ main = hspec $ do
           = Project.setApproval (PullRequestId 2) (Just (Approval "fred" Project.Merge 0))
           $ Project.setApproval (PullRequestId 1) (Just (Approval "fred" Project.Merge 1))
           $ fst $ runAction $ handleEventsTest
-            [ PullRequestOpened (PullRequestId 1) (Branch "p") (Sha "f34") "Untitled" "sally"
-            , PullRequestOpened (PullRequestId 2) (Branch "s") (Sha "g35") "Another untitled" "rachael"
+            [ PullRequestOpened (PullRequestId 1) (Branch "p") masterBranch (Sha "f34") "Untitled" "sally"
+            , PullRequestOpened (PullRequestId 2) (Branch "s") masterBranch (Sha "g35") "Another untitled" "rachael"
             ] Project.emptyProjectState
         results = defaultResults
           { resultIntegrate = [Right (Sha "38c")]
@@ -728,6 +804,7 @@ main = hspec $ do
       let
         pullRequest = PullRequest
           { Project.branch              = Branch "results/rachael"
+          , Project.baseBranch          = masterBranch
           , Project.sha                 = Sha "f35"
           , Project.title               = "Add my test results"
           , Project.author              = "rachael"
@@ -752,6 +829,7 @@ main = hspec $ do
       let
         pullRequest = PullRequest
           { Project.branch              = Branch "results/rachael"
+          , Project.baseBranch          = masterBranch
           , Project.sha                 = Sha "f35"
           , Project.title               = "Add my test results"
           , Project.author              = "rachael"
@@ -778,6 +856,7 @@ main = hspec $ do
       let
         pullRequest = PullRequest
           { Project.branch              = Branch "results/rachael"
+          , Project.baseBranch          = masterBranch
           , Project.sha                 = Sha "f35"
           , Project.title               = "Add my test results"
           , Project.author              = "rachael"
@@ -807,6 +886,7 @@ main = hspec $ do
       let
         pullRequest = PullRequest
           { Project.branch              = Branch "results/rachael"
+          , Project.baseBranch          = masterBranch
           , Project.sha                 = Sha "f35"
           , Project.title               = "Add my test results"
           , Project.author              = "rachael"
@@ -843,6 +923,7 @@ main = hspec $ do
       let
         pullRequest = PullRequest
           { Project.branch              = Branch "results/rachael"
+          , Project.baseBranch          = masterBranch
           , Project.sha                 = Sha "f35"
           , Project.title               = "Add my test results"
           , Project.author              = "rachael"
@@ -885,6 +966,7 @@ main = hspec $ do
           = Project.insertPullRequest
               (PullRequestId 1)
               (Branch "n7")
+              masterBranch
               (Sha "a39")
               "Add Nexus 7 experiment"
               (Username "tyrell")
@@ -899,7 +981,7 @@ main = hspec $ do
         results = defaultResults
           { resultIntegrate =
             [ Right $ Sha "b71"
-            , Left $ Logic.IntegrationFailure (Branch "master")
+            , Left $ Logic.IntegrationFailure masterBranch
             ]
           , resultPush = [ PushRejected ]
           }
@@ -924,6 +1006,7 @@ main = hspec $ do
       let pullRequest1 = PullRequest
             {
               Project.branch              = Branch "results/leon",
+              Project.baseBranch          = masterBranch,
               Project.sha                 = Sha "f35",
               Project.title               = "Add Leon test results",
               Project.author              = "rachael",
@@ -935,6 +1018,7 @@ main = hspec $ do
           pullRequest2 = PullRequest
             {
               Project.branch              = Branch "results/rachael",
+              Project.baseBranch          = masterBranch,
               Project.sha                 = Sha "f37",
               Project.title               = "Add my test results",
               Project.author              = "rachael",
@@ -968,6 +1052,7 @@ main = hspec $ do
           = Project.insertPullRequest
               (PullRequestId 1)
               (Branch "n7")
+              masterBranch
               (Sha "a39")
               "Add Nexus 7 experiment"
               (Username "tyrell")
@@ -1010,14 +1095,17 @@ main = hspec $ do
           title      = Github.title      (payload :: PullRequestPayload)
           prAuthor   = Github.author     (payload :: PullRequestPayload)
           prBranch   = Github.branch     (payload :: PullRequestPayload)
+          baseBranch = Github.baseBranch (payload :: PullRequestPayload)
       action     `shouldBe` Github.Opened
       owner      `shouldBe` "baxterthehacker"
       repository `shouldBe` "public-repo"
       number     `shouldBe` 1
       headSha    `shouldBe` (Sha "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c")
       prBranch   `shouldBe` (Branch "changes")
+      baseBranch `shouldBe` masterBranch
       title      `shouldBe` "Update the README with new information"
       prAuthor   `shouldBe` "baxterthehacker2"
+
 
     it "parses a CommentPayload from a created issue_comment correctly" $ do
       examplePayload <- readFile "tests/data/issue-comment-created-payload.json"
@@ -1151,6 +1239,7 @@ main = hspec $ do
           , repository = "repo"
           , number     = 1
           , branch     = Branch "results"
+          , baseBranch = masterBranch
           , sha        = Sha "b26354"
           , title      = "Add test results"
           , author     = "rachael"
@@ -1160,14 +1249,14 @@ main = hspec $ do
       let payload = testPullRequestPayload Github.Opened
           Just event = convertGithubEvent $ Github.PullRequest payload
       event `shouldBe`
-        (PullRequestOpened (PullRequestId 1) (Branch "results") (Sha "b26354") "Add test results" "rachael")
+        (PullRequestOpened (PullRequestId 1) (Branch "results") masterBranch (Sha "b26354") "Add test results" "rachael")
 
     it "converts a pull request reopened event" $ do
       let payload = testPullRequestPayload Github.Reopened
           Just event = convertGithubEvent $ Github.PullRequest payload
       -- Reopened is treated just like opened, there is no memory in the system.
       event `shouldBe`
-        (PullRequestOpened (PullRequestId 1) (Branch "results") (Sha "b26354") "Add test results" "rachael")
+        (PullRequestOpened (PullRequestId 1) (Branch "results") masterBranch (Sha "b26354") "Add test results" "rachael")
 
     it "converts a pull request closed event" $ do
       let payload = testPullRequestPayload Github.Closed
@@ -1252,8 +1341,8 @@ main = hspec $ do
     it "can be restored exactly after roundtripping through json" $ do
       let
         emptyState  = Project.emptyProjectState
-        singleState = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "071") "deckard"
-        candState   = candidateState (PullRequestId 2) (Branch "p") (Sha "073") "rachael" "tyrell" (Sha "079")
+        singleState = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "071") "deckard"
+        candState   = candidateState (PullRequestId 2) (Branch "p") masterBranch (Sha "073") "rachael" "tyrell" (Sha "079")
         Just emptyState'  = decode $ encode emptyState
         Just singleState' = decode $ encode singleState
         Just candState'   = decode $ encode candState
@@ -1267,7 +1356,7 @@ main = hspec $ do
       uuid       <- Uuid.nextRandom
       tmpBaseDir <- getTemporaryDirectory
       let fname = tmpBaseDir </> ("state-" ++ (show uuid) ++ ".json")
-          state = singlePullRequestState (PullRequestId 1) (Branch "p") (Sha "071") "deckard"
+          state = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "071") "deckard"
       Project.saveProjectState fname state
       Right state' <- Project.loadProjectState fname
       state `shouldBe` state'


### PR DESCRIPTION
This PR solves the issue of rejecting commands that are run on PRs that don't have "master" as the base branch. But, if you create a PR with a base branch "a", and then change the base branch to "master", the bot will still reject the commands, as the `PullRequest` data will be out of date. Solving [this issue](https://github.com/channable/hoff/issues/86) would allow updating the base branch when the PR gets edited. Once that issue is implemented, this PR will be ready to merge. Fixes #6  