### PR TITLE
Build Hoff in Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # Test output
 .hspec-failures
+
+# Nix build result
+result

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,6 +18,8 @@ blocks:
     task:
       secrets:
         - name: "opsbot-github-key"
+        # Keys needed to access our cachix cache.
+        - name: "cachix-channable-public"
 
       jobs:
         - name: "Build, test, package, ship"
@@ -45,6 +47,10 @@ blocks:
             - "./nix/install"
             - ". $HOME/.nix-profile/etc/profile.d/nix.sh"
 
+            # Install Cachix and use the Channable cache
+            - "nix-env -iA nixpkgs.cachix"
+            - "cachix use channable-public"
+
             # Bring all the tools from the pinned build environment into the PATH.
             - "export PATH=$(nix-build --no-out-link default.nix)/bin:$PATH"
 
@@ -53,9 +59,10 @@ blocks:
             # contains them.
             - "export LOCALE_ARCHIVE=$(nix-build --no-out-link locale.nix)/lib/locale/locale-archive"
 
-            - "stack setup"
-            - "stack --no-terminal build --split-objs"
-            - "stack --no-terminal test --split-objs"
+            # The stack builds are currently broken, see https://github.com/channable/hoff/issues/106
+            # - "stack setup"
+            # - "stack --no-terminal build --split-objs"
+            # - "stack --no-terminal test --split-objs"
 
             # Match the licenses of dependencies agains a whitelist, and fail
             # if anything is not whitelisted. Grep -v returns # 1 if nothing
@@ -67,6 +74,11 @@ blocks:
 
             # Check shell scripts for issues.
             - "shellcheck package/*.sh package/deb-postinst"
+
+            # Run build and tests in Nix, and push the result to Cachix.
+            # Because this is a public repository, and not everyone is using Nix,
+            # we keep the stack setup around. The Nix build however is used in production.
+            - "nix-build --no-out-link release.nix | cachix push channable-public"
 
             # Store a copy of the nix store. This will be refreshed daily, which
             # is more than sufficient for this repo.

--- a/hoff.nix
+++ b/hoff.nix
@@ -1,0 +1,85 @@
+{ lib, haskellPackages, nix-gitignore, git, coreutils, openssh }:
+  haskellPackages.mkDerivation {
+    pname = "hoff";
+    version = "0.25.0";
+
+    src =
+      let
+        # We do not want to include all files, because that leads to a lot of things that nix
+        # has to copy to the temporary build directory that we don't want to have in there
+        # (e.g. the `.stack-work` directory, the `.git` directory, etc.)
+        prefixWhitelist = builtins.map builtins.toString [
+          ./app
+          ./package
+          ./src
+          ./static
+          ./tests
+          ./hoff.cabal
+          ./stack.yaml
+          ./license
+        ];
+        # Compute source based on whitelist
+        whitelistFilter = path: _type: lib.any (prefix: lib.hasPrefix prefix path) prefixWhitelist;
+        gitignore = builtins.readFile ./.gitignore;
+        gitignoreFilter = nix-gitignore.gitignoreFilterPure whitelistFilter gitignore ./.;
+        whitelistedSrc = lib.cleanSourceWith {
+          src = lib.cleanSource ./.;
+          filter = gitignoreFilter;
+        };
+      in
+        whitelistedSrc;
+
+    isLibrary = false;
+    isExecutable = true;
+
+
+    executableToolDepends = [
+      git coreutils openssh
+    ];
+
+    testDepends = [
+      git coreutils openssh
+    ];
+
+
+    libraryHaskellDepends =
+      with haskellPackages; [
+        aeson
+        aeson-pretty
+        blaze-html
+        blaze-markup
+        bytestring
+        containers
+        cryptonite
+        directory
+        extra
+        file-embed
+        filepath
+        free
+        github
+        hspec
+        hspec-core
+        http-client
+        http-conduit
+        http-types
+        memory
+        monad-logger
+        optparse-applicative
+        process
+        process-extras
+        scotty
+        stm
+        text
+        text-format
+        time
+        uuid
+        vector
+        wai
+        warp
+        warp-tls
+      ];
+
+    homepage = "https://github.com/channable/hoff";
+
+    license = lib.licenses.asl20;
+  }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f752379bcc26134d12f2275435f0530593ea5c6",
-        "sha256": "1smfadbmb6kabjxd2xr99f4qwydynm156kc6kipb37j4y3zcfk21",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "sha256": "11d9m0c4r4kpr3jx3cqblw6ld4d8dwcfv1lk68ipp4c87knwv7fb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/2f752379bcc26134d12f2275435f0530593ea5c6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/530a53dcbc9437363471167a5e4762c5fcfa34a1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,5 @@
+let
+  pkgs = import ./nixpkgs-pinned.nix {};
+  hoff = pkgs.callPackage ./hoff.nix {};
+in
+  hoff

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -278,8 +278,8 @@ callGit userConfig args = do
       -- not prompt for things such as passphrases, because there is no
       -- interactive terminal.
       Process.env = Just
-        $ ("GIT_EDITOR", "/usr/bin/env true")
-        : ("GIT_SSH_COMMAND", "/usr/bin/ssh -F " ++ (Config.sshConfigFile userConfig))
+        $ ("GIT_EDITOR", "true")
+        : ("GIT_SSH_COMMAND", "ssh -F " ++ (Config.sshConfigFile userConfig))
         : ("GIT_TERMINAL_PROMPT", "0")
         : currentEnv
     }


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

In the past, we build Hoff in CI, on a Ubuntu 18.04 server.
We pushed the built apt package to our package repository.
We then ran the apt package on a 18.04 server, and life was good.

We then decided to limit access to our repository server from the outside, and as such we could not upload apt packages from CI.
We then decided to do our builds locally (see #101), and life seemed to be good again.

Then we discovered that something was amiss: the locally build packages did not run on the server.
Building Hoff locally on a 20.04 machine made it rely on glibc version 2.29, but the 18.04 server only has 20.04.

This PR tries to solve this problem once and for all by building with Nix.
The build is done in CI, and then pushed to Cachix.

Because of mismatch between the version of `base16-bytestring` pinned by Stack (0.1.1) and the version pinned by the `github` dependency in Nix (1.0), we had to upgrade the dependency.
Because of a changed function type, this leads to a few lines of changed code, and to the Stack builds being broken (see #106).

The other changed lines of Haskell code are because of packages in Nix not being in their expected location.