### PR TITLE
Wrap Hoff executable to set `LOCALE_ARCHIVE`

### DIFF
--- a/hoff.nix
+++ b/hoff.nix
@@ -1,4 +1,4 @@
-{ lib, haskellPackages, nix-gitignore, git, coreutils, openssh }:
+{ lib, haskellPackages, nix-gitignore, git, coreutils, openssh, glibcLocales, makeWrapper }:
   haskellPackages.mkDerivation {
     pname = "hoff";
     version = "0.25.0";
@@ -28,6 +28,14 @@
         };
       in
         whitelistedSrc;
+
+    buildTools = [ makeWrapper ];
+
+    postInstall = ''
+      # Set LOCALE_ARCHIVE so that glibc can find the locales it needs when running on Ubuntu
+      # machines.
+      wrapProgram $out/bin/hoff --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive
+    '';
 
     isLibrary = false;
     isExecutable = true;


### PR DESCRIPTION
On non-NixOS systems, the `LOCALE_ARCHIVE` needs to be set.

This is what the resulting executable looks like:

```bash
$ nix path-info --file release.nix
/nix/store/n0ha687mf03d45awqwgipwcbb2lgazj2-hoff-0.25.0
$ cat /nix/store/n0ha687mf03d45awqwgipwcbb2lgazj2-hoff-0.25.0/bin/hoff 
#! /nix/store/dzrvibwj2vjwqmc34wk3x1ffsjpp4av7-bash-4.4-p23/bin/bash -e
export LOCALE_ARCHIVE='/nix/store/lkg27i9ra2qn1nz49hdk2lq2dj57pbir-glibc-locales-2.32-54/lib/locale/locale-archive'
exec -a "$0" "/nix/store/n0ha687mf03d45awqwgipwcbb2lgazj2-hoff-0.25.0/bin/.hoff-wrapped"  "$@"
```