### PR TITLE
Allow extra whitespace in merge commands

### DIFF
--- a/.semaphore/prologue.sh
+++ b/.semaphore/prologue.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Shared commands for the set-up phase of jobs
+
+# This file is NOT usable with Semaphore's "commands_file" property, as this
+# puts all the comments in this file in the build output and requires us to
+# write all build steps on one line each. Instead, this file must be executed
+# in the build pipelines where we use it.
+
+# We don't use `set -x` here to show the run commands, because this would show
+# authentication tokens in the build output. Instead, `set -v` prints the
+# commands "as they are read".
+# We do want to exit immediately after encountering an error.
+# We also cannot use "set -u", as Semaphore's tooling uses unset variables in
+# some places (which we can't change).
+set -evo pipefail
+
+# Clear disk space by removing docker related services, mounts and files.
+sudo systemctl stop docker.service docker.socket
+
+if [[ $(findmnt /var/lib/docker) ]]; then
+  sudo umount /var/lib/docker
+fi
+
+if [[ -e "/dev/nbd0" ]]; then
+  sudo qemu-nbd --disconnect /dev/nbd0
+fi
+
+# Clear disk space by removing tooling that we don't use. This is needed to run
+# on the smallest machine type Semaphore offers, as this machine type has too
+# little disk space to build the package due to a lot of extra tooling that we
+# don't need. Removing these directories clears about 4 GiB.
+sudo rm -rf \
+    /home/semaphore/.rbenv \
+    /home/semaphore/.kerl \
+    /home/semaphore/.nvm \
+    /home/semaphore/.phpbrew \
+    /home/semaphore/.kiex \
+    /opt/google \
+    /opt/firefox-esr \
+    /opt/firefox-esr-prev \
+    /usr/local/golang \
+    /mnt/docker.qcow2

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,6 +33,9 @@ blocks:
 
             - "checkout"
 
+            # Free space on the disk in order to save the nix store and error on build failures.
+            - .semaphore/prologue.sh
+
             # Restore `/nix` cache. Create the directory first, otherwise we encounter
             # permission errors. We do this because the Semaphore cache is faster than
             # both Cachix and cache.nixos.org.

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -747,6 +747,46 @@ main = hspec $ do
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
         (\pr -> Project.approval pr == Just (Approval (Username "deckard") Project.MergeAndTag 0))
 
+    it "recognizes 'merge and  tag' command" $ do
+      let
+        prId = PullRequestId 1
+        state = singlePullRequestState prId (Branch "p") masterBranch (Sha "abc1234") "tyrell"
+
+        event = CommentAdded prId "deckard" "@bot merge and  tag"
+
+        results = defaultResults { resultIntegrate = [Right (Sha "def2345")] }
+        (state', actions) = runActionCustom results $ handleEventTest event state
+
+      actions `shouldBe`
+        [ AIsReviewer "deckard"
+        , ALeaveComment prId "Pull request approved for merge and tag by @deckard, rebasing now."
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
+        ]
+
+      fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
+        (\pr -> Project.approval pr == Just (Approval (Username "deckard") Project.MergeAndTag 0))
+
+    it "recognizes 'merge  and tag' command" $ do
+      let
+        prId = PullRequestId 1
+        state = singlePullRequestState prId (Branch "p") masterBranch (Sha "abc1234") "tyrell"
+
+        event = CommentAdded prId "deckard" "@bot merge  and tag"
+
+        results = defaultResults { resultIntegrate = [Right (Sha "def2345")] }
+        (state', actions) = runActionCustom results $ handleEventTest event state
+
+      actions `shouldBe`
+        [ AIsReviewer "deckard"
+        , ALeaveComment prId "Pull request approved for merge and tag by @deckard, rebasing now."
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
+        ]
+
+      fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
+        (\pr -> Project.approval pr == Just (Approval (Username "deckard") Project.MergeAndTag 0))
+
     it "recognizes 'merge and tag on friday' command" $ do
       let
         prId = PullRequestId 1


### PR DESCRIPTION
XRef: https://github.com/channable/hoff/issues/102

> it might also be more user-friendly to accept one or more spaces between the mention and the command instead of just one. ~ Riley

Yes, that is definitely more user-friendly!

---

Allowing extra whitespace in the merge commands to overcome the (somewhat) common double whitespace.

<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->
