### PR TITLE
Add some editor related files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 # Editor files
 *.swp
 *.swo
+*~
+/.idea
+/.vscode
+/TAGS
 /tags
 
 # Vagrant files


### PR DESCRIPTION
This adds `*~`, `/TAGS`, `/.idea` and `/.vscode` into `.gitignore`.

Since this is a simple change, there's no accompanying issue.