### PR TITLE
Add instructions on the readme file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,14 +3,10 @@
 Hoff is a bot for GitHub that enforces a clean history, and ensures that master
 always builds.
 
-[![Build Status][travis-img]][travis]
-
-Hoff intends to replace the merge button in the GitHub UI. Unlike GitHub\* and
-many other tools, Hoff integrates changes into master using a *rebase*. This
-keeps the history clean, free of random fork points and merge commits. (TODO:
-In the future Hoff will also enforce a commit message format.)
-
-\* [This is no longer true.](https://github.com/blog/2243-rebase-and-merge-pull-requests)
+Hoff intends to replace the merge button in the GitHub UI.  Hoff integrates
+changes into master using a *rebase*. This keeps the history clean, free of
+random fork points and merge commits.  (TODO: In the future Hoff will also
+enforce a commit message format.)
 
 Furthermore, Hoff implements the [Not Rocket Science Principle][not-rocket-science]
 of software engineering:
@@ -22,6 +18,32 @@ has been approved (through an LGTM comment left by a reviewer), it integrates
 the changes into master, and pushes those to a testing branch. When CI reports a
 successful build for this branch, master is forwarded to it. If the build fails,
 the commits never make it into master, keeping the build green at all times.
+
+
+## Using Hoff
+
+Supposing Hoff is set up to listen for the comment prefix `@hoffbot` with a
+matching GitHub user, you use it by commenting on a PR with any of the
+following commands:
+
+* `@hoffbot merge`: rebase then merge;
+* `@hoffbot merge and tag`: rebase, merge then tag.
+* `@hoffbot merge and deploy`: rebase, merge, tag then deploy;
+
+For all the commands, Hoff will wait for the builds to pass after rebasing and
+before merging.  When the PR is merged, GitHub closes the PR as merged and,
+when configured to automatically do so, deletes the PR branch.
+
+Hoff does not actually do the deploying.  It just adds a special marker to the
+tag message indicating to the CI job that the tag should be deployed.
+
+On Fridays, by default, Hoff refuses to do the above actions.  To force merges
+on Fridays, simply add `on friday` at the end of your commands, like so:
+
+* `@hoffbot merge on friday`;
+* `@hoffbot merge and tag on friday`.
+* `@hoffbot merge and deploy on friday`;
+
 
 ## Installing
 
@@ -70,9 +92,6 @@ More information is available in the doc directory:
  * [Background](doc/background.md): My original intention was more ambitious
    than building a GitHub bot. This document gives some background about what I
    want to build.
- * [Approach](doc/approach.md): Progress is made in many small steps. This
-   document outlines the current goals.
- * [Design](doc/design.md): Outlines the architecture of the application.
  * [Installing](doc/installing.md): The installation guide.
 
 ## License
@@ -81,8 +100,6 @@ Hoff is free software. It is licensed under the [Apache 2.0][apache2] license.
 It may be used both for commercial and non-commercial use under the conditions
 given in the license.
 
-[travis-img]:         https://travis-ci.org/ruuda/hoff.svg?branch=master
-[travis]:             https://travis-ci.org/ruuda/hoff
 [not-rocket-science]: https://graydon2.dreamwidth.org/1597.html
 [stack]:              https://haskellstack.org
 [nix]:                https://nixos.org/nix/


### PR DESCRIPTION
Closes #111

This PR adds instructions on how to use Hoff on the README file along with a few other minor README improvements:

* [x] add instructions on the readme file
* [x] remove broken links
* [x] remove the old badge that points to the Travis build of Ruud's repo.  Currently is not possible to add a badge for Semaphore due to the project being marked as private there, see issue #113.

_**Mr. PR reviewer**_: you may be interested in looking at the updated [readme.md](https://github.com/channable/hoff/tree/doc/readme-instructions#readme) before and/or after looking at the diff.