### PR TITLE
Abort merge after an "empty" rebase

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -736,6 +736,9 @@ describeStatus prId pr state = case Pr.classifyPullRequest pr of
   PrStatusIntegrated -> "The build succeeded."
   PrStatusIncorrectBaseBranch -> "Merge rejected: the target branch must be the integration branch."
   PrStatusWrongFixups -> "Pull request cannot be integrated as it contains fixup commits that do not belong to any other commits."
+  PrStatusEmptyRebase -> "Empty rebase. \
+                         \ Have the changes already been merged into the target branch? \
+                         \ Aborting."
   PrStatusFailedConflict ->
     let
       BaseBranch targetBranchName = Pr.baseBranch pr

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -93,6 +93,7 @@ data PullRequestStatus
   | PrStatusIntegrated                -- Integrated, build passed, merged into target branch.
   | PrStatusIncorrectBaseBranch       -- ^ Integration branch not being valid.
   | PrStatusWrongFixups               -- Failed to integrate due to the presence of orphan fixup commits.
+  | PrStatusEmptyRebase               -- Rebase was empty (changes already in the target branch?)
   | PrStatusFailedConflict            -- Failed to integrate due to merge conflict.
   | PrStatusFailedBuild (Maybe Text)  -- Integrated, but the build failed. Field should contain the URL to a page explaining the build failure.
   deriving (Eq)
@@ -280,6 +281,7 @@ classifyPullRequest pr = case approval pr of
     NotIntegrated -> PrStatusApproved
     IncorrectBaseBranch -> PrStatusIncorrectBaseBranch
     Conflicted _ WrongFixups -> PrStatusWrongFixups
+    Conflicted _ EmptyRebase -> PrStatusEmptyRebase
     Conflicted _ _  -> PrStatusFailedConflict
     Integrated _ buildStatus -> case buildStatus of
       BuildPending    -> PrStatusBuildPending


### PR DESCRIPTION
Closes #75.

Consider that besides `master`, we have two branches `first` and `second` with accompanying PRs and the `second` branch is a fork of the `first`, like so:

![first is a fork of master and second is a fork of first](https://user-images.githubusercontent.com/3999598/170029069-30e39384-6986-4b61-806d-cd5fb462ff87.png)

If `second` is merged into `master` before the `first`, trying to merge `first` results in an empty rebase, just pointing `first` to `master`.  This PR makes it so that Hoff aborts the merge when this happens with an appropriate message:

> Empty rebase.  Have the changes already been merged into the target branch?  Aborting.

For full details please see issue #75.