### PR TITLE
Hackathon: make Hoff interface a little more "hoffelijk" (courteous)

### DIFF
--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -159,13 +159,7 @@ viewProjectQueues info state = do
     let approvedSorted = sortOn (\(_, pr, _) -> approvalOrder <$> Project.approval pr) approved
     viewList viewPullRequestWithApproval info approvedSorted
 
-  let awaitingApproval = filterPrs (== Project.PrStatusAwaitingApproval)
-  unless (null awaitingApproval) $ do
-    h2 "Awaiting approval"
-    viewList viewPullRequest info awaitingApproval
-
   let failed = filterPrs prFailed
-
   unless (null failed) $ do
     h2 "Failed"
     -- TODO: Also render failure reason: conflicted or build failed.
@@ -177,6 +171,11 @@ viewProjectQueues info state = do
   unless (null integrated) $ do
     h2 "Recently integrated"
     viewList viewPullRequestWithApproval info integrated
+
+  let awaitingApproval = reverse $ filterPrs (== Project.PrStatusAwaitingApproval)
+  unless (null awaitingApproval) $ do
+    h2 "Awaiting approval"
+    viewList viewPullRequest info awaitingApproval
 
 -- Render the html for the queues in a project, excluding the header and footer.
 viewGroupedProjectQueues :: [(ProjectInfo, ProjectState)] -> Html
@@ -198,13 +197,7 @@ viewGroupedProjectQueues projects = do
     h2 "Approved"
     mapM_ (uncurry $ viewList' viewPullRequestWithApproval) approved
 
-  let awaitingApproval = filterPrs (== Project.PrStatusAwaitingApproval)
-  unless (null awaitingApproval) $ do
-    h2 "Awaiting approval"
-    mapM_ (uncurry $ viewList' viewPullRequest) awaitingApproval
-
   let failed = filterPrs prFailed
-
   unless (null failed) $ do
     h2 "Failed"
     -- TODO: Also render failure reason: conflicted or build failed.
@@ -216,6 +209,11 @@ viewGroupedProjectQueues projects = do
   unless (null integrated) $ do
     h2 "Recently integrated"
     mapM_ (uncurry $ viewList' viewPullRequestWithApproval) integrated
+
+  let awaitingApproval = reverse $ filterPrs (== Project.PrStatusAwaitingApproval)
+  unless (null awaitingApproval) $ do
+    h2 "Awaiting approval"
+    mapM_ (uncurry $ viewList' viewPullRequest) awaitingApproval
 
   where
     viewList'
@@ -233,8 +231,9 @@ viewPullRequest info (PullRequestId n) pullRequest =
   let
     url = format "https://github.com/{}/{}/pull/{}"
       (Project.owner info, Project.repository info, n)
-  in
+  in do
     a ! href (toValue url) $ toHtml $ Project.title pullRequest
+    span ! class_ "prId" $ toHtml $ "#" <> (show n)
 
 viewPullRequestWithApproval :: ProjectInfo -> PullRequestId -> PullRequest -> Html
 viewPullRequestWithApproval info prId pullRequest = do

--- a/static/style.css
+++ b/static/style.css
@@ -105,6 +105,13 @@ p
   clear: both;
 }
 
+span.prId
+{
+  color: #adaca4;
+  display: inline-block;
+  margin-left: 0.391rem;
+}
+
 span.review
 {
   color: #adaca4;


### PR DESCRIPTION
Some minor improvements to the build overview of a single repository:
- Reverse the order of PRs awaiting approval, since the newest ones are most likely to be merged first.
- Show the PR id next to the title to improve readability of a list of PRs.
- Move the 'Awaiting builds' section to the bottom, as it can result in quite a long list pushing other sections down.

Thanks to @RileyApeldoorn for the help!

---

### Screenshot
![Screenshot 2022-06-10 at 17-25-19 tiesjan_hoff-test-repo](https://user-images.githubusercontent.com/5622927/173098742-30a1408d-8fea-4d2d-9a3a-1f193d234d4a.png)


<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->