### PR TITLE
Merge train: candidates with parents

### DIFF
--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -469,8 +469,8 @@ eventLoopSpec = parallel $ do
 
         -- Extract the sha of the rebased commit from the project state.
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
@@ -529,8 +529,8 @@ eventLoopSpec = parallel $ do
 
         -- Extract the sha of the rebased commit from the project state.
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
@@ -570,8 +570,8 @@ eventLoopSpec = parallel $ do
           ]
 
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
 
         void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
@@ -630,8 +630,8 @@ eventLoopSpec = parallel $ do
           ]
 
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
 
         void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
@@ -694,8 +694,8 @@ eventLoopSpec = parallel $ do
 
         -- Extract the sha of the rebased commit from the project state.
         let
-          Just (_prId, pullRequest6)      = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest6
+          Just (_prId, pullRequest6)        = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest6
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
@@ -704,8 +704,8 @@ eventLoopSpec = parallel $ do
         -- Repeat for the other pull request, which should be the candidate by
         -- now.
         let
-          Just (_prId, pullRequest4)       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest4
+          Just (_prId, pullRequest4)         = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ _ = Project.integrationStatus pullRequest4
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
       history `shouldBe`
@@ -739,14 +739,14 @@ eventLoopSpec = parallel $ do
           ]
 
         let
-          Just (_prId, pullRequest6)      = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest6
+          Just (_prId, pullRequest6)        = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest6
 
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         let
-          Just (_prId, pullRequest4)       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest4
+          Just (_prId, pullRequest4)         = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ _ = Project.integrationStatus pullRequest4
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
       history `shouldBe`
@@ -830,7 +830,7 @@ eventLoopSpec = parallel $ do
         -- result.
         let Just (prId, pullRequest4) = Project.getIntegrationCandidate state
         prId `shouldBe` pr4
-        let Integrated _ buildStatus = Project.integrationStatus pullRequest4
+        let Integrated _ buildStatus _ = Project.integrationStatus pullRequest4
         buildStatus `shouldBe` BuildPending
 
       -- We did not send a build status notification for c4, so it should not
@@ -868,8 +868,8 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- The push should have failed, hence there should still be an
@@ -878,8 +878,8 @@ eventLoopSpec = parallel $ do
 
         -- Again notify build success, now for the new commit.
         let
-          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
+          Just (_prId, pullRequest')         = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ _ = Project.integrationStatus pullRequest'
         state'' <- runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been
@@ -923,14 +923,14 @@ eventLoopSpec = parallel $ do
         git ["push", "origin", refSpec (c4, masterBranch)]
 
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let
-          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
+          Just (_prId, pullRequest')         = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ _ = Project.integrationStatus pullRequest'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been
@@ -999,14 +999,14 @@ eventLoopSpec = parallel $ do
         git ["push", "origin", refSpec (Git.TagName "v2")]
 
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let
-          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
+          Just (_prId, pullRequest')         = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ _ = Project.integrationStatus pullRequest'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been integrated properly,
@@ -1072,8 +1072,8 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
         void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
@@ -1114,14 +1114,14 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let
-          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
+          Just (_prId, pullRequest')         = Project.getIntegrationCandidate state'
+          Project.Integrated rebasedSha' _ _ = Project.integrationStatus pullRequest'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
@@ -1168,8 +1168,8 @@ eventLoopSpec = parallel $ do
         -- tell the loop that building the commit succeeded.
 
         let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (_prId, pullRequest)         = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         --The pull request should not be integrated. Moreover, the presence of
@@ -1205,8 +1205,8 @@ eventLoopSpec = parallel $ do
           ]
 
         let
-          Just (prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+          Just (prId, pullRequest)          = Project.getIntegrationCandidate state
+          Project.Integrated rebasedSha _ _ = Project.integrationStatus pullRequest
 
         prId `shouldBe` pr8
 


### PR DESCRIPTION
Closes: #77?

First explorations on implementing a merge train:

* the "candidate" maybe is now a "candidates" list
* the integration status includes the parent PR

I am not sure if this is the right way to go at the end, hence the junk/ prefix in the branch name. I am thinking of perhaps eliminating the concept of a list of candidates altogether, and infer this fact from the collection of PRs.