### PR TITLE
Merge train: infer candidate from state

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -353,12 +353,10 @@ handlePullRequestClosedByUser :: PullRequestId -> ProjectState -> Action Project
 handlePullRequestClosedByUser = handlePullRequestClosed User
 
 handlePullRequestClosed :: PRCloseCause -> PullRequestId -> ProjectState -> Action ProjectState
-handlePullRequestClosed closingReason pr state = Pr.deletePullRequest pr <$>
-    case Pr.integrationCandidate state of
-      Just candidatePr | candidatePr == pr -> do
-        leaveComment pr $ prClosingMessage closingReason
-        pure state { Pr.integrationCandidate = Nothing }
-      _notCandidatePr -> pure state
+handlePullRequestClosed closingReason pr state = do
+  when (pr `elem` Pr.integratedPullRequests state) $
+    leaveComment pr $ prClosingMessage closingReason
+  pure $ Pr.deletePullRequest pr state
 
 handlePullRequestEdited :: PullRequestId -> Text -> BaseBranch -> ProjectState -> Action ProjectState
 handlePullRequestEdited prId newTitle newBaseBranch state =
@@ -530,18 +528,15 @@ handleMergeRequested projectConfig prId author state pr approvalType = do
 
 handleBuildStatusChanged :: Sha -> BuildStatus -> ProjectState -> ProjectState
 handleBuildStatusChanged buildSha newStatus state =
+  Pr.updatePullRequests setBuildStatus state
+  where
   -- If there is an integration candidate, and its integration sha matches that
   -- of the build, then update the build status for that pull request. Otherwise
   -- do nothing.
-  let
-    setBuildStatus pullRequest = case Pr.integrationStatus pullRequest of
-      Integrated candidateSha _oldStatus | candidateSha == buildSha ->
-        pullRequest { Pr.integrationStatus = Integrated buildSha newStatus }
-      _ -> pullRequest
-  in
-    case Pr.integrationCandidate state of
-      Just candidateId -> Pr.updatePullRequest candidateId setBuildStatus state
-      Nothing          -> state
+  setBuildStatus pullRequest = case Pr.integrationStatus pullRequest of
+    Integrated candidateSha _oldStatus | candidateSha == buildSha ->
+      pullRequest { Pr.integrationStatus = Integrated buildSha newStatus }
+    _ -> pullRequest
 
 -- Query the GitHub API to resolve inconsistencies between our state and GitHub.
 synchronizeState :: ProjectState -> Action ProjectState
@@ -585,38 +580,31 @@ synchronizeState stateInitial =
 proceed :: ProjectState -> Action ProjectState
 proceed state = do
   state' <- provideFeedback state
-  case Pr.getIntegrationCandidate state' of
-    Just candidate -> proceedCandidate candidate state'
-    -- No current integration candidate, find the next one.
-    Nothing -> case Pr.candidatePullRequests state' of
-      -- No pull requests eligible, do nothing.
-      []     -> return state'
-      -- Found a new candidate, try to integrate it.
-      pr : _ -> tryIntegratePullRequest pr state'
+  case (Pr.getIntegrationCandidates state', Pr.candidatePullRequests state') of
+                           -- Proceed with an already integrated candidate
+    (candidate:_, _)    -> proceedCandidate candidate state'
+                           -- Found a new candidate, try to integrate it.
+    (_,           pr:_) -> tryIntegratePullRequest pr state'
+                           -- No pull requests eligible, do nothing.
+    (_,           _)    -> return state'
 
 -- TODO: Get rid of the tuple; just pass the ID and do the lookup with fromJust.
 proceedCandidate :: (PullRequestId, PullRequest) -> ProjectState -> Action ProjectState
 proceedCandidate (pullRequestId, pullRequest) state =
   case Pr.integrationStatus pullRequest of
-    NotIntegrated ->
-      tryIntegratePullRequest pullRequestId state
-
-    IncorrectBaseBranch ->
-      -- It shouldn't come to this point; a PR with an incorrect base branch is
-      -- never considered as a candidate.
-      pure $ Pr.setIntegrationCandidate Nothing state
-
-    Conflicted _branch _ ->
-      -- If it conflicted, it should no longer be the integration candidate.
-      pure $ Pr.setIntegrationCandidate Nothing state
+    NotIntegrated -> pure state -- dead code / unreachable
 
     Integrated sha buildStatus -> case buildStatus of
       BuildPending   -> pure state
       BuildSucceeded -> pushCandidate (pullRequestId, pullRequest) sha state
-      BuildFailed _  -> do
-        -- If the build failed, this is no longer a candidate.
-        pure $ Pr.setIntegrationCandidate Nothing $
-          Pr.setNeedsFeedback pullRequestId True state
+                        -- If the build failed, give feedback on the PR
+      BuildFailed _  -> pure $ Pr.setNeedsFeedback pullRequestId True state
+
+    Promoted -> pure state -- dead code / unreachable
+
+    Conflicted _branch _ -> pure state -- dead code / unreachable
+
+    IncorrectBaseBranch -> pure state -- dead code / unreachable
 
 -- Given a pull request id, returns the name of the GitHub ref for that pull
 -- request, so it can be fetched.
@@ -652,11 +640,10 @@ tryIntegratePullRequest pr state =
           Pr.setNeedsFeedback pr True state
 
       Right (Sha sha) -> do
-        -- If it succeeded, update the integration candidate, and set the build
-        -- to pending, as pushing should have triggered a build.
+        -- If it succeeded, set the build to pending,
+        -- as pushing should have triggered a build.
         pure
           $ Pr.setIntegrationStatus pr (Integrated (Sha sha) BuildPending)
-          $ Pr.setIntegrationCandidate (Just pr)
           $ Pr.setNeedsFeedback pr True
           $ state
 
@@ -705,7 +692,7 @@ pushCandidate (pullRequestId, pullRequest) newHead state =
       -- GitHub will mark the pull request as closed, and when we receive that
       -- event, we delete the pull request from the state. Until then, reset
       -- the integration candidate, so we proceed with the next pull request.
-      PushOk -> pure $ Pr.setIntegrationCandidate Nothing state
+      PushOk -> pure $ Pr.setIntegrationStatus pullRequestId Promoted state
       -- If something was pushed to the target branch while the candidate was
       -- being tested, try to integrate again and hope that next time the push
       -- succeeds.

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -75,15 +75,12 @@ singlePullRequestState pr prBranch baseBranch prSha prAuthor =
   in
     fst $ runAction $ handleEventTest event Project.emptyProjectState
 
-candidateState :: PullRequestId -> Branch -> BaseBranch -> Sha -> Username -> Username -> Sha -> ProjectState
-candidateState pr prBranch baseBranch prSha prAuthor approvedBy candidateSha =
-  let
-    state = Project.setIntegrationStatus pr
-      (Project.Integrated candidateSha Project.BuildPending)
-      $ Project.setApproval pr (Just (Approval approvedBy Project.Merge 0))
-      $ singlePullRequestState pr prBranch baseBranch prSha prAuthor
-  in
-    state { Project.integrationCandidate = Just pr }
+candidateState
+  :: PullRequestId -> Branch -> BaseBranch -> Sha -> Username -> Username -> Sha -> ProjectState
+candidateState pr prBranch baseBranch prSha prAuthor approvedBy candidateSha
+  = Project.setIntegrationStatus pr (Project.Integrated candidateSha Project.BuildPending)
+  $ Project.setApproval pr (Just (Approval approvedBy Project.Merge 0))
+  $ singlePullRequestState pr prBranch baseBranch prSha prAuthor
 
 -- Types and functions to mock running an action without actually doing anything.
 
@@ -281,13 +278,13 @@ main = hspec $ do
       let event  = PullRequestClosed (PullRequestId 1)
           state  = candidateState (PullRequestId 1) (Branch "p") masterBranch (Sha "ea0") "frank" "deckard" (Sha "cf4")
           state' = fst $ runAction $ handleEventTest event state
-      Project.integrationCandidate state' `shouldBe` Nothing
+      Project.integratedPullRequests state' `shouldBe` []
 
     it "does not modify the integration candidate if a different PR was closed" $ do
       let event  = PullRequestClosed (PullRequestId 1)
           state  = candidateState (PullRequestId 2) (Branch "p") masterBranch (Sha "a38") "franz" "deckard" (Sha "ed0")
           state' = fst $ runAction $ handleEventTest event state
-      Project.integrationCandidate state' `shouldBe` (Just $ PullRequestId 2)
+      Project.integratedPullRequests state' `shouldBe` [PullRequestId 2]
 
     it "loses approval after the PR commit has changed" $ do
       let event  = PullRequestCommitChanged (PullRequestId 1) (Sha "def")
@@ -418,7 +415,7 @@ main = hspec $ do
         state  = candidateState (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "johanna" "deckard" (Sha "84c")
         state' = fst $ runAction $ handleEventTest event state
         pr     = fromJust $ Project.lookupPullRequest (PullRequestId 1) state'
-      Project.integrationStatus pr `shouldBe` Project.Integrated (Sha "84c") Project.BuildSucceeded
+      Project.integrationStatus pr `shouldBe` Project.Promoted
 
     it "ignores a build status change for commits that are not the integration candidate" $ do
       let
@@ -584,7 +581,7 @@ main = hspec $ do
       -- The first pull request should be dropped, and a comment should be
       -- left indicating why. Then the second pull request should be at the
       -- front of the queue.
-      Project.integrationCandidate state' `shouldBe` Just (PullRequestId 2)
+      Project.integratedPullRequests state' `shouldBe` [PullRequestId 2]
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
@@ -1011,7 +1008,7 @@ main = hspec $ do
         ]
 
       Project.approval pr `shouldBe` Nothing
-      Project.integrationCandidate state' `shouldBe` Nothing
+      Project.integratedPullRequests state' `shouldBe` []
 
     it "shows an appropriate message when the commit is changed on an approved PR" $ do
       let
@@ -1036,7 +1033,7 @@ main = hspec $ do
         ]
 
       Project.approval pr `shouldBe` Nothing
-      Project.integrationCandidate state' `shouldBe` Nothing
+      Project.integratedPullRequests state' `shouldBe` []
 
 
   describe "Logic.proceedUntilFixedPoint" $ do
@@ -1051,7 +1048,7 @@ main = hspec $ do
           , resultPush = [PushRejected "test"]
           }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-        (prId, pullRequest) = fromJust $ Project.getIntegrationCandidate state'
+        [(prId, pullRequest)] = Project.getIntegrationCandidates state'
       Project.integrationStatus pullRequest `shouldBe` Project.Integrated (Sha "38c") Project.BuildPending
       prId    `shouldBe` PullRequestId 1
       actions `shouldBe`
@@ -1072,7 +1069,7 @@ main = hspec $ do
           , resultPush = [PushRejected "test"]
           }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-        (prId, pullRequest) = fromJust $ Project.getIntegrationCandidate state'
+        [(prId, pullRequest)] = Project.getIntegrationCandidates state'
       Project.integrationStatus pullRequest `shouldBe` Project.Integrated (Sha "38c") Project.BuildPending
       prId    `shouldBe` PullRequestId 2
       actions `shouldBe`
@@ -1095,15 +1092,14 @@ main = hspec $ do
           }
         state = ProjectState
           { Project.pullRequests         = IntMap.singleton 1 pullRequest
-          , Project.integrationCandidate = Just $ PullRequestId 1
           , Project.pullRequestApprovalIndex = 1
           }
         results = defaultResults { resultIntegrate = [Right (Sha "38e")] }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-        candidate = Project.getIntegrationCandidate state'
+        candidates = Project.getIntegrationCandidates state'
       -- After a successful push, the candidate should be gone.
-      candidate `shouldBe` Nothing
-      actions   `shouldBe` [ATryPromote (Branch "results/rachael") (Sha "38d")]
+      candidates `shouldBe` []
+      actions    `shouldBe` [ATryPromote (Branch "results/rachael") (Sha "38d")]
 
     it "pushes and tags with a new version after a successful build (merge and tag)" $ do
       let
@@ -1120,7 +1116,6 @@ main = hspec $ do
           }
         state = ProjectState
           { Project.pullRequests         = IntMap.singleton 1 pullRequest
-          , Project.integrationCandidate = Just $ PullRequestId 1
           , Project.pullRequestApprovalIndex = 1
           }
         results = defaultResults
@@ -1128,10 +1123,10 @@ main = hspec $ do
           , resultGetChangelog = [Just "changelog"]
           }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-        candidate = Project.getIntegrationCandidate state'
+        candidates = Project.getIntegrationCandidates state'
       -- After a successful push, the candidate should be gone.
-      candidate `shouldBe` Nothing
-      actions   `shouldBe`
+      candidates `shouldBe` []
+      actions    `shouldBe`
         [ ATryPromoteWithTag (Branch "results/rachael") (Sha "38d") (TagName "v2")
             (TagMessage "v2\n\nchangelog")
         , ALeaveComment (PullRequestId 1)
@@ -1153,7 +1148,6 @@ main = hspec $ do
           }
         state = ProjectState
           { Project.pullRequests         = IntMap.singleton 1 pullRequest
-          , Project.integrationCandidate = Just $ PullRequestId 1
           , Project.pullRequestApprovalIndex = 1
           }
         results = defaultResults
@@ -1161,10 +1155,10 @@ main = hspec $ do
           , resultGetChangelog = [Just "changelog"]
           }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-        candidate = Project.getIntegrationCandidate state'
+        candidates = Project.getIntegrationCandidates state'
       -- After a successful push, the candidate should be gone.
-      candidate `shouldBe` Nothing
-      actions   `shouldBe`
+      candidates `shouldBe` []
+      actions    `shouldBe`
         [ ATryPromoteWithTag (Branch "results/rachael") (Sha "38d") (TagName "v2")
             (TagMessage "v2 (autodeploy)\n\nchangelog")
         , ALeaveComment (PullRequestId 1)
@@ -1186,16 +1180,15 @@ main = hspec $ do
           }
         state = ProjectState
           { Project.pullRequests         = IntMap.singleton 1 pullRequest
-          , Project.integrationCandidate = Just $ PullRequestId 1
           , Project.pullRequestApprovalIndex = 1
           }
         results = defaultResults { resultIntegrate = [Right (Sha "38e")]
                                  , resultGetLatestVersion = [Left (TagName "abcdef")] }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-        candidate = Project.getIntegrationCandidate state'
+        candidates = Project.getIntegrationCandidates state'
       -- After a successful push, the candidate should be gone.
-      candidate `shouldBe` Nothing
-      actions   `shouldBe` [ ALeaveComment (PullRequestId 1) "@deckard Sorry, I could not tag your PR. The previous tag `abcdef` seems invalid"
+      candidates `shouldBe` []
+      actions    `shouldBe` [ ALeaveComment (PullRequestId 1) "@deckard Sorry, I could not tag your PR. The previous tag `abcdef` seems invalid"
                            , ATryPromote (Branch "results/rachael") (Sha "38d")]
 
 
@@ -1216,7 +1209,6 @@ main = hspec $ do
           }
         state = ProjectState
           { Project.pullRequests         = IntMap.singleton 1 pullRequest
-          , Project.integrationCandidate = Just $ PullRequestId 1
           , Project.pullRequestApprovalIndex = 1
           }
         -- Run 'proceedUntilFixedPoint', and pretend that pushes fail (because
@@ -1226,7 +1218,7 @@ main = hspec $ do
           , resultPush = [PushRejected "test"]
           }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-        (_, pullRequest') = fromJust $ Project.getIntegrationCandidate state'
+        [(_, pullRequest')] = Project.getIntegrationCandidates state'
 
       Project.integrationStatus   pullRequest' `shouldBe` Project.Integrated (Sha "38e") Project.BuildPending
       Project.integrationAttempts pullRequest' `shouldBe` [Sha "38d"]
@@ -1253,7 +1245,6 @@ main = hspec $ do
           }
         state = ProjectState
           { Project.pullRequests         = IntMap.singleton 1 pullRequest
-          , Project.integrationCandidate = Just $ PullRequestId 1
           , Project.pullRequestApprovalIndex = 1
           }
         -- Run 'proceedUntilFixedPoint', and pretend that pushes fail (because
@@ -1264,7 +1255,7 @@ main = hspec $ do
           , resultGetChangelog = [Just "changelog"]
           }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-        (_, pullRequest') = fromJust $ Project.getIntegrationCandidate state'
+        [(_, pullRequest')] = Project.getIntegrationCandidates state'
 
       Project.integrationStatus   pullRequest' `shouldBe` Project.Integrated (Sha "38e") Project.BuildPending
       Project.integrationAttempts pullRequest' `shouldBe` [Sha "38d"]
@@ -1353,16 +1344,16 @@ main = hspec $ do
           state = ProjectState
             {
               Project.pullRequests         = prMap,
-              Project.integrationCandidate = Nothing,
               Project.pullRequestApprovalIndex = 2
             }
           -- Proceeding should pick the next pull request as candidate.
           results = defaultResults { resultIntegrate = [Right (Sha "38e")] }
           (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
-          Just (cId, _candidate) = Project.getIntegrationCandidate state'
+          [(cId, _candidate)] = Project.getIntegrationCandidates state'
       cId     `shouldBe` PullRequestId 2
       actions `shouldBe`
-        [ ATryIntegrate "Merge #2: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "f37") False
+        [ ATryPromote (Branch "results/leon") (Sha "38d")
+        , ATryIntegrate "Merge #2: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "f37") False
         , ALeaveComment (PullRequestId 2) "Rebased as 38e, waiting for CI \x2026"
         ]
 


### PR DESCRIPTION
... in preparation for #77 (partly closes: #77)

The changes in this PR do not change Hoff behaviour, the high level functionality should be the same.

Instead of maintaining a global candidate, we infer it from the state always.  This is in preparation for merge trains (#77), where we will have multiple builds running in parallel and thus multiple candidates.

* The `ProjectState` datatype is now simpler and easier to maintain (before we could risk it being inconsistent);
* Some code paths are now simpler, as we don't have to do the work maintaining the global candidate;
* There is a new explicit integration status `Promoted` to signify that the PR branch is now part of `master`, before this was signified by being `Integrated ... BuildSucceeded` but not being the global candidate.

A linear search on the number of open PRs is imposed.  I believe this is not a problem because:

* the number of PRs should be at most a few dozen, examples:
    - there are only [5 open PRs on channable/hoff](https://github.com/channable/hoff/pulls) currently;
    - a dozen open PRs seems to be a reasonable average (:wink:);
    - a busy project (:wink:) should have between 100 and 200 open PRs in which a linear search is still reasonable;
    - ... and we could still have way more than that without suffering significant performance impact (1000 or 10000 __open__ PRs).
* we already perform [linear search](https://github.com/channable/hoff/blob/0c3e53b1c1ec2fc8b4e1d68d5dc02fb278a65d1e/src/Project.hs#L298-L315) for [other operations](https://github.com/channable/hoff/blob/0c3e53b1c1ec2fc8b4e1d68d5dc02fb278a65d1e/src/Project.hs#L366-L369), the candidate was just a special case in where we don't.  If we were to actually get rid of linear search altogether, we perhaps should have a more generic solution that covers all cases.  (If linear search were to be a problem, we would already be suffering from it.)
* with #77, we are bound to perform a linear search on the candidate PRs anyway.

### Notes

This is an alternative to PR #130.  Here, instead of changing the datatype of `integrationCandidate`, we simply remove it and try to infer from the rest of the state every time.