### PR TITLE
Merge train: qualify the test branch by PR id

### DIFF
--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,4 +1,5 @@
--- Hoff -- A gatekeeper for your commits
+-- Hoff
+-- A gatekeeper for your commits
 -- Copyright 2016 Ruud van Asseldonk
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,13 +88,14 @@ candidateState pr prBranch baseBranch prSha prAuthor approvedBy candidateSha
 data ActionFlat
   = ATryIntegrate
     { mergeMessage         :: Text
-    , integrationCandidate :: (Branch, Sha)
+    , integrationCandidate :: (PullRequestId, Branch, Sha)
     , alwaysAddMergeCommit :: Bool
     }
   | ATryPromote Branch Sha
   | ATryPromoteWithTag Branch Sha TagName TagMessage
   | ALeaveComment PullRequestId Text
   | AIsReviewer Username
+  | ACleanupTestBranch PullRequestId
   | AGetPullRequest PullRequestId
   | AGetOpenPullRequests
   deriving (Eq, Show)
@@ -209,6 +211,9 @@ runActionRws =
       TryPromoteWithTag prBranch headSha newTag tagMessage cont -> do
         Rws.tell [ATryPromoteWithTag prBranch headSha newTag tagMessage]
         cont . (Right newTag, ) <$> takeResultPush
+      CleanupTestBranch pr cont -> do
+        Rws.tell [ACleanupTestBranch pr]
+        pure cont
       LeaveComment pr body cont -> do
         Rws.tell [ALeaveComment pr body]
         pure cont
@@ -449,7 +454,8 @@ main = hspec $ do
       actions1 `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1)
             "Failed to rebase, please rebase manually using\n\n\
             \    git rebase --interactive --autosquash origin/master p"
@@ -475,7 +481,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
@@ -502,7 +509,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3) "Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
@@ -559,7 +567,8 @@ main = hspec $ do
       actionsPermuted `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "dec") False
+        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 2, Branch "refs/pull/2/head", Sha "dec") False
         , ALeaveComment (PullRequestId 2) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
@@ -593,12 +602,14 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a38") False
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2) "Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , ALeaveComment (PullRequestId 1) "Abandoning this pull request because it was closed."
-        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "dec") False
+        , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 2, Branch "refs/pull/2/head", Sha "dec") False
         , ALeaveComment (PullRequestId 2) "Rebased as b72, waiting for CI …"
         ]
 
@@ -705,7 +716,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment prId "Pull request approved for merge and deploy by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\n" (Branch "refs/pull/1/head", Sha "abc1234") True
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") True
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -725,7 +737,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment prId "Pull request approved for merge and deploy by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\n" (Branch "refs/pull/1/head", Sha "abc1234") True
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") True
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -745,7 +758,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment prId "Pull request approved for merge and tag by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -765,7 +779,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment prId "Pull request approved for merge and tag by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -785,7 +800,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment prId "Pull request approved for merge and tag by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -805,7 +821,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment prId "Pull request approved for merge and tag by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -825,7 +842,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment prId "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -845,7 +863,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment prId "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -878,7 +897,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "bot"
         , ALeaveComment prId "Pull request approved for merge by @bot, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: bot\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: bot\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment prId "Rebased as def2345, waiting for CI \x2026"
         ]
 
@@ -944,7 +964,7 @@ main = hspec $ do
         , ALeaveComment prId "Pull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate
             { mergeMessage = "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
-            , integrationCandidate = (Branch "refs/pull/1/head", Sha "abc1234")
+            , integrationCandidate = (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234")
             , alwaysAddMergeCommit = False
             }
         , ALeaveComment (PullRequestId 1)
@@ -986,7 +1006,8 @@ main = hspec $ do
         , ALeaveComment (PullRequestId 1) "Merge rejected: the target branch must be the integration branch."
         , AIsReviewer (Username "deckard")
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment (PullRequestId 1) "Rebased as def2345, waiting for CI \8230"
         ]
 
@@ -1010,7 +1031,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer (Username "deckard")
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment (PullRequestId 1) "Rebased as def2345, waiting for CI \8230"
         , ALeaveComment (PullRequestId 1) "Stopping integration because the PR changed after approval."
         ]
@@ -1035,7 +1057,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer (Username "deckard")
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "abc1234") False
+        , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") False
         , ALeaveComment (PullRequestId 1) "Rebased as def2345, waiting for CI \8230"
         , ALeaveComment (PullRequestId 1) "Stopping integration because the PR changed after approval."
         ]
@@ -1060,7 +1083,8 @@ main = hspec $ do
       Project.integrationStatus pullRequest `shouldBe` Project.Integrated (Sha "38c") (Project.BuildPending Nothing)
       prId    `shouldBe` PullRequestId 1
       actions `shouldBe`
-        [ ATryIntegrate "Merge #1: Untitled\n\nApproved-by: fred\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "f34") False
+        [ ATryIntegrate "Merge #1: Untitled\n\nApproved-by: fred\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "f34") False
         , ALeaveComment (PullRequestId 1) "Rebased as 38c, waiting for CI \x2026"
         ]
     it "finds a new candidate with multiple PRs" $ do
@@ -1081,7 +1105,8 @@ main = hspec $ do
       Project.integrationStatus pullRequest `shouldBe` Project.Integrated (Sha "38c") (Project.BuildPending Nothing)
       prId    `shouldBe` PullRequestId 2
       actions `shouldBe`
-        [ ATryIntegrate "Merge #2: Another untitled\n\nApproved-by: fred\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "g35") False
+        [ ATryIntegrate "Merge #2: Another untitled\n\nApproved-by: fred\nAuto-deploy: false\n"
+                        (PullRequestId 2, Branch "refs/pull/2/head", Sha "g35") False
         , ALeaveComment (PullRequestId 2) "Rebased as 38c, waiting for CI \x2026"
         ]
 
@@ -1107,7 +1132,9 @@ main = hspec $ do
         candidates = getIntegrationCandidates state'
       -- After a successful push, the candidate should be gone.
       candidates `shouldBe` []
-      actions    `shouldBe` [ATryPromote (Branch "results/rachael") (Sha "38d")]
+      actions    `shouldBe` [ ATryPromote (Branch "results/rachael") (Sha "38d")
+                            , ACleanupTestBranch (PullRequestId 1)
+                            ]
 
     it "pushes and tags with a new version after a successful build (merge and tag)" $ do
       let
@@ -1139,6 +1166,7 @@ main = hspec $ do
             (TagMessage "v2\n\nchangelog")
         , ALeaveComment (PullRequestId 1)
             "@deckard I tagged your PR with `v2`. Don't forget to deploy it!"
+        , ACleanupTestBranch (PullRequestId 1)
         ]
 
     it "pushes and tags with a new version after a successful build (merge and deploy)" $ do
@@ -1171,6 +1199,7 @@ main = hspec $ do
             (TagMessage "v2 (autodeploy)\n\nchangelog")
         , ALeaveComment (PullRequestId 1)
             "@deckard I tagged your PR with `v2`. It is scheduled for autodeploy!"
+        , ACleanupTestBranch (PullRequestId 1)
         ]
 
     it "pushes after successful build even if tagging failed" $ do
@@ -1197,7 +1226,9 @@ main = hspec $ do
       -- After a successful push, the candidate should be gone.
       candidates `shouldBe` []
       actions    `shouldBe` [ ALeaveComment (PullRequestId 1) "@deckard Sorry, I could not tag your PR. The previous tag `abcdef` seems invalid"
-                           , ATryPromote (Branch "results/rachael") (Sha "38d")]
+                            , ATryPromote (Branch "results/rachael") (Sha "38d")
+                            , ACleanupTestBranch (PullRequestId 1)
+                            ]
 
 
     it "restarts the sequence after a rejected push" $ do
@@ -1232,7 +1263,8 @@ main = hspec $ do
       Project.integrationAttempts pullRequest' `shouldBe` [Sha "38d"]
       actions `shouldBe`
         [ ATryPromote (Branch "results/rachael") (Sha "38d")
-        , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "f35") False
+        , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "f35") False
         , ALeaveComment (PullRequestId 1) "Rebased as 38e, waiting for CI \x2026"
         ]
 
@@ -1269,7 +1301,8 @@ main = hspec $ do
       Project.integrationAttempts pullRequest' `shouldBe` [Sha "38d"]
       actions `shouldBe`
         [ ATryPromoteWithTag (Branch "results/rachael") (Sha "38d") (TagName "v2") (TagMessage "v2\n\nchangelog")
-        , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "f35") False
+        , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "f35") False
         , ALeaveComment (PullRequestId 1) "Rebased as 38e, waiting for CI \x2026"
         ]
 
@@ -1309,13 +1342,15 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a39") False
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "a39") False
           -- The first rebase succeeds.
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
           -- The first promotion attempt fails
         , ATryPromote (Branch "n7") (Sha "b71")
           -- The second rebase fails.
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a39") False
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "a39") False
         , ALeaveComment (PullRequestId 1)
             "Failed to rebase, please rebase manually using\n\n\
             \    git rebase --interactive --autosquash origin/master n7"
@@ -1361,7 +1396,9 @@ main = hspec $ do
       cId     `shouldBe` PullRequestId 2
       actions `shouldBe`
         [ ATryPromote (Branch "results/leon") (Sha "38d")
-        , ATryIntegrate "Merge #2: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/2/head", Sha "f37") False
+        , ACleanupTestBranch (PullRequestId 1)
+        , ATryIntegrate "Merge #2: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 2, Branch "refs/pull/2/head", Sha "f37") False
         , ALeaveComment (PullRequestId 2) "Rebased as 38e, waiting for CI \x2026"
         ]
 
@@ -1393,7 +1430,8 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1) "Pull request approved for merge by @deckard, rebasing now."
-        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n" (Branch "refs/pull/1/head", Sha "a39") False
+        , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "a39") False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
         , ALeaveComment (PullRequestId 1) "Waiting on CI job: https://status.example.com/b71"
         , ALeaveComment (PullRequestId 1) "The build failed: https://example.com/build-status\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
@@ -1750,7 +1788,7 @@ main = hspec $ do
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
-                        (Branch "refs/pull/1/head", Sha "ab1")
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         False
         , ALeaveComment (PullRequestId 1) "Rebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
@@ -1763,22 +1801,25 @@ main = hspec $ do
                         "Pull request approved for merge by @deckard, \
                         \waiting for rebase behind 2 pull requests."
         , ATryPromote (Branch "fst") (Sha "1ab")
+        , ACleanupTestBranch (PullRequestId 1)
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
-                        (Branch "refs/pull/2/head", Sha "cd2")
+                        (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         False
         , ALeaveComment (PullRequestId 2) "Rebased as 2bc, waiting for CI …"
         , ALeaveComment (PullRequestId 2) "Waiting on CI job: example.com/2bc"
         , ATryPromote (Branch "snd") (Sha "2bc")
+        , ACleanupTestBranch (PullRequestId 2)
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
-                        (Branch "refs/pull/3/head", Sha "ef3")
+                        (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         False
         , ALeaveComment (PullRequestId 3) "Rebased as 3cd, waiting for CI …"
         , ALeaveComment (PullRequestId 3) "Waiting on CI job: example.com/3cd"
         , ATryPromote (Branch "trd") (Sha "3cd")
+        , ACleanupTestBranch (PullRequestId 3)
         ]
 
     it "handles a sequence of merges: success, failure, success" $ do
@@ -1837,7 +1878,7 @@ main = hspec $ do
         , ATryIntegrate "Merge #9: Ninth PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
-                        (Branch "refs/pull/9/head", Sha "ab9")
+                        (PullRequestId 9, Branch "refs/pull/9/head", Sha "ab9")
                         False
         , ALeaveComment (PullRequestId 9) "Rebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
@@ -1850,10 +1891,11 @@ main = hspec $ do
                         "Pull request approved for merge by @deckard, \
                         \waiting for rebase behind 2 pull requests."
         , ATryPromote (Branch "nth") (Sha "1ab")
+        , ACleanupTestBranch (PullRequestId 9)
         , ATryIntegrate "Merge #8: Eighth PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
-                        (Branch "refs/pull/8/head", Sha "cd8")
+                        (PullRequestId 8, Branch "refs/pull/8/head", Sha "cd8")
                         False
         , ALeaveComment (PullRequestId 8) "Rebased as 2bc, waiting for CI …"
         , ALeaveComment (PullRequestId 8) "Waiting on CI job: example.com/2bc"
@@ -1865,9 +1907,10 @@ main = hspec $ do
         , ATryIntegrate "Merge #7: Seventh PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
-                        (Branch "refs/pull/7/head", Sha "ef7")
+                        (PullRequestId 7, Branch "refs/pull/7/head", Sha "ef7")
                         False
         , ALeaveComment (PullRequestId 7) "Rebased as 3cd, waiting for CI …"
         , ALeaveComment (PullRequestId 7) "Waiting on CI job: example.com/3cd"
         , ATryPromote (Branch "sth") (Sha "3cd")
+        , ACleanupTestBranch (PullRequestId 7)
         ]


### PR DESCRIPTION
Partly closes: #77 

Qualify the test branch by PR id in order to prepare for a future change where we will have multiple PR ids.  Instead of building on `testing`, we build on `testing/<id>`.

This is made on top of #131.

### Side effect

There is a little side effect of this, while the tests for a PR is running, GitHub will show a "compare & pull request" suggestion box:

![compare-and-pull-request](https://user-images.githubusercontent.com/3999598/179753836-0fb9839b-161c-41a1-a2d6-3fbaa6e6debc.png)
![compare-and-pull-request-w](https://user-images.githubusercontent.com/3999598/179753845-7c7405d2-a25a-444e-b004-6b11e4a7df9f.png)

It should disappear after the build passes or fails and the branch is deleted by Hoff.

Ideally, there should be a setting on GitHub to tell it to ignore branches starting with a given `testing/` prefix.  But it seems this is not the case.  According to my (lack of) findings, there is no way to set this:

* https://stackoverflow.com/questions/71162762/how-to-get-rid-of-githubs-compare-pull-request-suggestion
* https://github.community/t/how-to-fix-compare-pull-request/161488
* [https://duckduckgo.com/?q=github+dismiss+"compare+%26+pull+request"](https://duckduckgo.com/?q=github+dismiss+"compare+%26+pull+request")
* [https://www.google.com/search?q=github+dismiss+"compare+%26+pull+request"](https://www.google.com/search?q=github+dismiss+"compare+%26+pull+request")

One could think of mitigating this by having a small set of testing slots for which we start by dismissing manually:

* `testing/1`
* `testing/2`
* `testing/3`
* `testing/4`
* `testing/5`
* `testing/6`

However, this solution would not work, because:

* limit the maximum number of PRs in our merge train (#77);
* make it difficult to manage in terms of code (keeping track of free slots);
* make it difficult to know which testing branches are actually being used in case of build failures (with PR numbers it is easy!);
* ... all of this by not actually solving the problem from the get-go -- at least in the _first six builds per project_ we would have to manually dismiss each "compare and pull request" suggestion.

So it seems we are stuck with the minor side effect of seeing that button while the build builds.