### PR TITLE
Report URLs of pending status checks

### DIFF
--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -74,7 +74,7 @@ eventFromCommentPayload payload =
 
 mapCommitStatus :: Github.CommitStatus -> Maybe Text.Text -> Project.BuildStatus
 mapCommitStatus status url = case status of
-  Github.Pending -> Project.BuildPending
+  Github.Pending -> Project.BuildPending url
   Github.Success -> Project.BuildSucceeded
   Github.Failure -> Project.BuildFailed url
   Github.Error   -> Project.BuildFailed url

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -831,7 +831,8 @@ eventLoopSpec = parallel $ do
         let Just (prId, pullRequest4) = Project.getIntegrationCandidate state
         prId `shouldBe` pr4
         let Integrated _ buildStatus = Project.integrationStatus pullRequest4
-        buildStatus `shouldBe` BuildPending
+        -- Expect no CI url
+        buildStatus `shouldBe` BuildPending Nothing
 
       -- We did not send a build status notification for c4, so it should not
       -- have been integrated.

--- a/tools/send-webhook
+++ b/tools/send-webhook
@@ -94,7 +94,7 @@ cat <<JSON
 	},
 	"sha": "$commit",
 	"state": "$state",
-	"target_url": null
+	"target_url": $target
 }
 JSON
 }
@@ -124,9 +124,17 @@ build-status)
 	event=
 	commit="$1"
 	state="$2"
+	target="$3"
 
 	[ -n "$commit" ] || errxit "Full commit sha should be provided as the 1st argument"
 	[ -n "$state" ] || state=success
+
+	# If this is a URL make sure it has quote marks, if null make sure it doesn't.
+	if [ -z "$target" ]; then
+		target="null"
+	else
+		target="\"$target\""
+	fi
 
 	event="status"
 	build-status-payload >webhook-data.json


### PR DESCRIPTION
This PR allows `hoff` to report the `target_url` of pending builds, giving users an indication of which job `hoff` is waiting for. This is shown both as a comment on the PR, and an additional link in the headline for pull requests where a CI URL is available (i.e. pending and failed jobs, since we don't currently keep the URL of succeeded jobs).

Screenshots:
![Screenshot from 2022-07-21 15-15-17](https://user-images.githubusercontent.com/29676050/180224008-8847efaa-60d1-44b8-a7c0-fbb3cdb03f1e.png)

![Screenshot from 2022-07-21 15-15-07](https://user-images.githubusercontent.com/29676050/180224028-b3238983-989c-4813-9659-30058dfe05ac.png)

I'm slightly unsure if this will actually go off in practice. This info is given when the build status changes to pending with a non-null `target_url`, but I have no concrete intuition for when this would occur in practice. I'm hoping when the status check starts it will change the state from `BuildPending Nothing` to `BuildPending (Just url)`.

Closes #26
Closes #109
