### PR TITLE
(Re-)infer candidate from state

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -353,12 +353,10 @@ handlePullRequestClosedByUser :: PullRequestId -> ProjectState -> Action Project
 handlePullRequestClosedByUser = handlePullRequestClosed User
 
 handlePullRequestClosed :: PRCloseCause -> PullRequestId -> ProjectState -> Action ProjectState
-handlePullRequestClosed closingReason pr state = Pr.deletePullRequest pr <$>
-    case Pr.integrationCandidate state of
-      Just candidatePr | candidatePr == pr -> do
-        leaveComment pr $ prClosingMessage closingReason
-        pure state { Pr.integrationCandidate = Nothing }
-      _notCandidatePr -> pure state
+handlePullRequestClosed closingReason pr state = do
+  when (pr `elem` Pr.integratedPullRequests state) $
+    leaveComment pr $ prClosingMessage closingReason
+  pure $ Pr.deletePullRequest pr state
 
 handlePullRequestEdited :: PullRequestId -> Text -> BaseBranch -> ProjectState -> Action ProjectState
 handlePullRequestEdited prId newTitle newBaseBranch state =
@@ -529,24 +527,19 @@ handleMergeRequested projectConfig prId author state pr approvalType = do
     else pure state''
 
 handleBuildStatusChanged :: Sha -> BuildStatus -> ProjectState -> Action ProjectState
-handleBuildStatusChanged buildSha newStatus state =
-  -- If there is an integration candidate, and its integration sha matches that
-  -- of the build, then update the build status for that pull request. Otherwise
-  -- do nothing.
-  let
-    setBuildStatus prId pullRequest = case Pr.integrationStatus pullRequest of
-      Integrated candidateSha _oldStatus | candidateSha == buildSha -> do
-        let pullRequest' = pullRequest { Pr.integrationStatus = Integrated buildSha newStatus }
-        -- Sometimes we want to leave an informative comment on the PR. This isn't for things
-        -- that require user feedback like build failures.
-        case newStatus of
-          BuildPending (Just url) -> pullRequest' <$ leaveComment prId ("Waiting on CI job: " <> url)
-          _                       -> pure pullRequest'
-      _ -> pure pullRequest
-    in
-    case Pr.integrationCandidate state of
-      Just candidateId -> Pr.updatePullRequestM candidateId (setBuildStatus candidateId) state
-      Nothing          -> pure state
+handleBuildStatusChanged buildSha newStatus = pure . Pr.updatePullRequests setBuildStatus
+  where
+  setBuildStatus pr = case Pr.integrationStatus pr of
+    -- If there is an integration candidate, and its integration sha matches that of the build,
+    -- then update the build status for that pull request. Otherwise do nothing.
+    Integrated candidateSha _ | candidateSha == buildSha ->
+      pr { Pr.integrationStatus = Integrated buildSha newStatus
+         , Pr.needsFeedback = case newStatus of
+                              BuildPending (Just _) -> True
+                              BuildFailed _         -> True
+                              _                     -> Pr.needsFeedback pr -- unchanged
+         }
+    _ -> pr
 
 -- Query the GitHub API to resolve inconsistencies between our state and GitHub.
 synchronizeState :: ProjectState -> Action ProjectState
@@ -590,38 +583,23 @@ synchronizeState stateInitial =
 proceed :: ProjectState -> Action ProjectState
 proceed state = do
   state' <- provideFeedback state
-  case Pr.getIntegrationCandidate state' of
-    Just candidate -> proceedCandidate candidate state'
-    -- No current integration candidate, find the next one.
-    Nothing -> case Pr.candidatePullRequests state' of
-      -- No pull requests eligible, do nothing.
-      []     -> return state'
-      -- Found a new candidate, try to integrate it.
-      pr : _ -> tryIntegratePullRequest pr state'
+  case (Pr.integratedPullRequests state', Pr.candidatePullRequests state') of
+                           -- Proceed with an already integrated candidate
+    (candidate:_, _)    -> proceedCandidate candidate state'
+                           -- Found a new candidate, try to integrate it.
+    (_,           pr:_) -> tryIntegratePullRequest pr state'
+                           -- No pull requests eligible, do nothing.
+    (_,           _)    -> return state'
 
--- TODO: Get rid of the tuple; just pass the ID and do the lookup with fromJust.
-proceedCandidate :: (PullRequestId, PullRequest) -> ProjectState -> Action ProjectState
-proceedCandidate (pullRequestId, pullRequest) state =
-  case Pr.integrationStatus pullRequest of
-    NotIntegrated ->
-      tryIntegratePullRequest pullRequestId state
-
-    IncorrectBaseBranch ->
-      -- It shouldn't come to this point; a PR with an incorrect base branch is
-      -- never considered as a candidate.
-      pure $ Pr.setIntegrationCandidate Nothing state
-
-    Conflicted _branch _ ->
-      -- If it conflicted, it should no longer be the integration candidate.
-      pure $ Pr.setIntegrationCandidate Nothing state
-
-    Integrated sha buildStatus -> case buildStatus of
-      BuildPending _ -> pure state
-      BuildSucceeded -> pushCandidate (pullRequestId, pullRequest) sha state
-      BuildFailed _  -> do
-        -- If the build failed, this is no longer a candidate.
-        pure $ Pr.setIntegrationCandidate Nothing $
-          Pr.setNeedsFeedback pullRequestId True state
+-- | Pushes the given integrated PR to be the new master if the build succeeded
+proceedCandidate :: PullRequestId -> ProjectState -> Action ProjectState
+proceedCandidate pullRequestId state =
+  case Pr.lookupPullRequest pullRequestId state of
+  Nothing -> pure state -- should not be reachable when called from 'proceed'
+  Just pullRequest ->
+    case Pr.integrationStatus pullRequest of
+    Integrated sha BuildSucceeded -> pushCandidate (pullRequestId, pullRequest) sha state
+    _                             -> pure state -- BuildFailed/BuildPending
 
 -- Given a pull request id, returns the name of the GitHub ref for that pull
 -- request, so it can be fetched.
@@ -657,12 +635,11 @@ tryIntegratePullRequest pr state =
           Pr.setNeedsFeedback pr True state
 
       Right (Sha sha) -> do
-        -- If it succeeded, update the integration candidate, and set the build
-        -- to pending, as pushing should have triggered a build.
+        -- If it succeeded, set the build to pending,
+        -- as pushing should have triggered a build.
         pure
           -- The build pending has no URL here, we need to wait for semaphore
           $ Pr.setIntegrationStatus pr (Integrated (Sha sha) (BuildPending Nothing))
-          $ Pr.setIntegrationCandidate (Just pr)
           $ Pr.setNeedsFeedback pr True
           $ state
 
@@ -711,7 +688,7 @@ pushCandidate (pullRequestId, pullRequest) newHead state =
       -- GitHub will mark the pull request as closed, and when we receive that
       -- event, we delete the pull request from the state. Until then, reset
       -- the integration candidate, so we proceed with the next pull request.
-      PushOk -> pure $ Pr.setIntegrationCandidate Nothing state
+      PushOk -> pure $ Pr.setIntegrationStatus pullRequestId Promoted state
       -- If something was pushed to the target branch while the candidate was
       -- being tested, try to integrate again and hope that next time the push
       -- succeeds.
@@ -742,7 +719,7 @@ describeStatus prId pr state = case Pr.classifyPullRequest pr of
   PrStatusBuildPending url ->
     let Sha sha = fromJust $ getIntegrationSha pr
     in case url of
-         Just url' -> Text.concat ["CI job started [here](", url', ")."]
+         Just url' -> Text.concat ["Waiting on CI job: ", url']
          Nothing   -> Text.concat ["Rebased as ", sha, ", waiting for CI …"]
   PrStatusIntegrated -> "The build succeeded."
   PrStatusIncorrectBaseBranch -> "Merge rejected: the target branch must be the integration branch."

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -21,7 +21,6 @@ import Control.Monad (forM_, void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Logger (runNoLoggingT)
 import Data.Map (Map)
-import Data.Maybe (isJust)
 import Data.Set (Set)
 import Data.Text (Text)
 import Prelude hiding (appendFile, writeFile)
@@ -368,6 +367,14 @@ withTestEnv' body = do
       where
         (ys, zs) = span (Text.isPrefixOf "    ") xs
 
+-- | lists the integration Shas from the state for all PRs which are Integrated
+integrationShas :: ProjectState -> [Sha]
+integrationShas state = [ sha
+                        | prId <- Project.integratedPullRequests state
+                        , Just pr <- [Project.lookupPullRequest prId state]
+                        , Integrated sha _ <- [Project.integrationStatus pr]
+                        ]
+
 eventLoopSpec :: Spec
 eventLoopSpec = parallel $ do
   describe "The main event loop" $ do
@@ -468,9 +475,7 @@ eventLoopSpec = parallel $ do
           ]
 
         -- Extract the sha of the rebased commit from the project state.
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
@@ -528,9 +533,7 @@ eventLoopSpec = parallel $ do
           ]
 
         -- Extract the sha of the rebased commit from the project state.
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
@@ -569,9 +572,7 @@ eventLoopSpec = parallel $ do
             Logic.CommentAdded pr6 "rachael" "@bot merge and tag"
           ]
 
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
 
         void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
@@ -629,9 +630,7 @@ eventLoopSpec = parallel $ do
             Logic.CommentAdded pr6 "rachael" "@bot merge and deploy"
           ]
 
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
 
         void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
@@ -693,9 +692,7 @@ eventLoopSpec = parallel $ do
           ]
 
         -- Extract the sha of the rebased commit from the project state.
-        let
-          Just (_prId, pullRequest6)      = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest6
+        let [rebasedSha] = integrationShas state
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
@@ -703,9 +700,7 @@ eventLoopSpec = parallel $ do
 
         -- Repeat for the other pull request, which should be the candidate by
         -- now.
-        let
-          Just (_prId, pullRequest4)       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest4
+        let [rebasedSha'] = integrationShas state'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
       history `shouldBe`
@@ -738,15 +733,11 @@ eventLoopSpec = parallel $ do
             Logic.CommentAdded pr4 "rachael" "@bot merge and tag"
           ]
 
-        let
-          Just (_prId, pullRequest6)      = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest6
+        let [rebasedSha] = integrationShas state
 
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
-        let
-          Just (_prId, pullRequest4)       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest4
+        let [rebasedSha'] = integrationShas state'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
       history `shouldBe`
@@ -828,9 +819,9 @@ eventLoopSpec = parallel $ do
 
         -- The second pull request should still be pending, awaiting the build
         -- result.
-        let Just (prId, pullRequest4) = Project.getIntegrationCandidate state
-        prId `shouldBe` pr4
-        let Integrated _ buildStatus = Project.integrationStatus pullRequest4
+        Project.integratedPullRequests state `shouldBe` [pr4]
+        let Just pullRequest4 = Project.lookupPullRequest pr4 state
+            Integrated _ buildStatus = Project.integrationStatus pullRequest4
         -- Expect no CI url
         buildStatus `shouldBe` BuildPending Nothing
 
@@ -868,24 +859,20 @@ eventLoopSpec = parallel $ do
 
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- The push should have failed, hence there should still be an
         -- integration candidate.
-        Project.getIntegrationCandidate state' `shouldSatisfy` isJust
+        Project.integratedPullRequests state' `shouldSatisfy` (not . null)
 
         -- Again notify build success, now for the new commit.
-        let
-          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
+        let [rebasedSha'] = integrationShas state'
         state'' <- runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been
         -- integrated properly, so there should not be a new candidate.
-        Project.getIntegrationCandidate state'' `shouldBe` Nothing
+        Project.integratedPullRequests state'' `shouldBe` []
 
       history `shouldBe`
         [ "*   Merge #6"
@@ -923,15 +910,11 @@ eventLoopSpec = parallel $ do
         git ["fetch", "origin", "ahead"] -- The ref for commit c4.
         git ["push", "origin", refSpec (c4, masterBranch)]
 
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
-        let
-          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
+        let [rebasedSha'] = integrationShas state'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been
@@ -999,15 +982,11 @@ eventLoopSpec = parallel $ do
         git ["tag", "-a", "v2", "-m", "v2", refSpec c4]
         git ["push", "origin", refSpec (Git.TagName "v2")]
 
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
-        let
-          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
+        let [rebasedSha'] = integrationShas state'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been integrated properly,
@@ -1072,9 +1051,7 @@ eventLoopSpec = parallel $ do
 
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
         void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
@@ -1114,15 +1091,11 @@ eventLoopSpec = parallel $ do
 
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
-        let
-          Just (_prId, pullRequest')       = Project.getIntegrationCandidate state'
-          Project.Integrated rebasedSha' _ = Project.integrationStatus pullRequest'
+        let [rebasedSha'] = integrationShas state'
         void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
@@ -1168,15 +1141,13 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
 
-        let
-          Just (_prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        let [rebasedSha] = integrationShas state
         state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
 
         --The pull request should not be integrated. Moreover, the presence of
         --orphan fixups should make the PR ineligible for being a candidate for integration.
         --That is, we expect no candidates for integration.
-        Project.getIntegrationCandidate state' `shouldBe` Nothing
+        Project.integratedPullRequests state' `shouldBe` []
 
       -- Here we expect that the fixup commit is not present.
       history `shouldBe`
@@ -1205,11 +1176,9 @@ eventLoopSpec = parallel $ do
             Logic.CommentAdded pr8 "rachael" "@bot merge"
           ]
 
-        let
-          Just (prId, pullRequest)       = Project.getIntegrationCandidate state
-          Project.Integrated rebasedSha _ = Project.integrationStatus pullRequest
+        Project.integratedPullRequests state `shouldBe` [pr8]
 
-        prId `shouldBe` pr8
+        let [rebasedSha] = integrationShas state
 
         -- merging PR#8 implies all changes from PR#6 are already in master
 
@@ -1219,7 +1188,7 @@ eventLoopSpec = parallel $ do
             Logic.CommentAdded pr6 "rachael" "@bot merge"
           ]
 
-        Project.getIntegrationCandidate state' `shouldBe` Nothing
+        Project.integratedPullRequests state' `shouldBe` []
 
         let Just pullRequest' = Project.lookupPullRequest pr6 state'
         Project.integrationStatus pullRequest' `shouldBe`


### PR DESCRIPTION
Fixes: #131

This reapplies the changes of #131 starting from a version where tests assure that Hoff is not stuck in an infinite comment loop.  The summary of #131 still holds:

> The changes in this PR do not change Hoff behaviour, the high level functionality should be the same.
> 
> Instead of maintaining a global candidate, we infer it from the state always.  This is in preparation for merge trains (#77), where we will have multiple builds running in parallel and thus multiple candidates.
> 
> * The `ProjectState` datatype is now simpler and easier to maintain (before we could risk it being inconsistent);
> * Some code paths are now simpler, as we don't have to do the work maintaining the global candidate;
> * There is a new explicit integration status `Promoted` to signify that the PR branch is now part of `master`, before this was signified by being `Integrated ... BuildSucceeded` but not being the global candidate.
> 
> A linear search on the number of open PRs is imposed.  I believe this is not a problem because:
> 
> * the number of PRs should be at most a few dozen, examples:
>     - there are only [5 open PRs on channable/hoff](https://github.com/channable/hoff/pulls) currently;
>     - a dozen open PRs seems to be a reasonable average (:wink:);
>     - a busy project (:wink:) should have between 100 and 200 open PRs in which a linear search is still reasonable;
>     - ... and we could still have way more than that without suffering significant performance impact (1000 or 10000 __open__ PRs).
> * we already perform [linear search](https://github.com/channable/hoff/blob/0c3e53b1c1ec2fc8b4e1d68d5dc02fb278a65d1e/src/Project.hs#L298-L315) for [other operations](https://github.com/channable/hoff/blob/0c3e53b1c1ec2fc8b4e1d68d5dc02fb278a65d1e/src/Project.hs#L366-L369), the candidate was just a special case in where we don't.  If we were to actually get rid of linear search altogether, we perhaps should have a more generic solution that covers all cases.  (If linear search were to be a problem, we would already be suffering from it.)
> * with #77, we are bound to perform a linear search on the candidate PRs anyway.

## TODO

* [x] https://github.com/channable/hoff/pull/139
    * [x] to detect the infinite comment loop
* [x] rebase revert of revert of #131 on top of the new master
* [x] fix the issue
    * [x] PRs with `BuildFailed` are not candidates
    * [x] Use `needsFeedback` on `handleBuildStatusChanged`
* [x] test that failing PRs do not "clog" the queue
    * [x] using GitHub
    * [x] in the actual test files