### PR TITLE
Split BuildPending into BuildStarted.

### DIFF
--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -73,11 +73,13 @@ eventFromCommentPayload payload =
     _ -> Nothing
 
 mapCommitStatus :: Github.CommitStatus -> Maybe Text.Text -> Project.BuildStatus
-mapCommitStatus status url = case status of
-  Github.Pending -> Project.BuildPending url
+mapCommitStatus status murl = case status of
+  Github.Pending -> case murl of
+                    Nothing -> Project.BuildPending
+                    Just url -> Project.BuildStarted url
   Github.Success -> Project.BuildSucceeded
-  Github.Failure -> Project.BuildFailed url
-  Github.Error   -> Project.BuildFailed url
+  Github.Failure -> Project.BuildFailed murl
+  Github.Error   -> Project.BuildFailed murl
 
 eventFromCommitStatusPayload :: CommitStatusPayload -> Logic.Event
 eventFromCommitStatusPayload payload =

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -849,7 +849,7 @@ eventLoopSpec = parallel $ do
         let Just pullRequest4 = Project.lookupPullRequest pr4 state
             Integrated _ buildStatus = Project.integrationStatus pullRequest4
         -- Expect no CI url
-        buildStatus `shouldBe` BuildPending Nothing
+        buildStatus `shouldBe` BuildPending
 
       -- We did not send a build status notification for c4, so it should not
       -- have been integrated.


### PR DESCRIPTION
In preparation for: #137.
Closes: #77.

This changes how the status is represented to something more explicit and descriptive:

```haskell
BuildPending Nothing                     -> BuildPending
BuildPending (Just "ci.example.com/...") -> BuildStarted "ci.example.com/..."
```

This will make the change in #137 much [nicer and simpler](https://github.com/channable/hoff/pull/137/commits/8e440b03e414eb7434f2436d82fd38d9fd166dea).

I checked and this does not affect the parsing of status files during an upgrade.

There are two other somewhat unrelated changes explained below.

## Build status wording

... and slightly change the build status comment wording to "[CI job](https://channable.semaphoreci.com/workflows/c40f133f-02f0-47ca-bd15-df0d24c10c9b?pipeline_id=dd100824-9db3-4fb8-8d63-4e56ce85ee5a) started."

## Rendering Status + Commit Hash on the web interface

... and change web rendering of CI jobs.  Besides the link to the CI, we also now include a link to the commit in GitHub.  

### Before:

![old](https://user-images.githubusercontent.com/3999598/181797854-87dd9ebc-7a0d-4353-9c75-3bfcddbe5e5f.png)

### After:

![new](https://user-images.githubusercontent.com/3999598/182328720-61817857-90f6-4ec1-a2d0-9ceb7dd04293.png)

The icons are clickable and so are the commit hashes:

* [Add Miles "Tails" Prower (fake)](https://github.com/channable/hoff/pull/146)`#110` | [🟡](https://channable.semaphoreci.com/workflows/c40f133f-02f0-47ca-bd15-df0d24c10c9b?pipeline_id=dd100824-9db3-4fb8-8d63-4e56ce85ee5a) [e711b80](https://github.com/channable/hoff/commit/42d0af0a66d227de260fb3561f0cc57f91dcb1e4) | [CI build](https://channable.semaphoreci.com/workflows/c40f133f-02f0-47ca-bd15-df0d24c10c9b?pipeline_id=dd100824-9db3-4fb8-8d63-4e56ce85ee5a)
* [Add Knuckles (fake)](https://github.com/channable/hoff/pull/146)`#109` | [❌](https://channable.semaphoreci.com/workflows/c40f133f-02f0-47ca-bd15-df0d24c10c9b?pipeline_id=dd100824-9db3-4fb8-8d63-4e56ce85ee5a) [95a8b8f](https://github.com/channable/hoff/commit/42d0af0a66d227de260fb3561f0cc57f91dcb1e4) | [CI build](https://channable.semaphoreci.com/workflows/c40f133f-02f0-47ca-bd15-df0d24c10c9b?pipeline_id=dd100824-9db3-4fb8-8d63-4e56ce85ee5a)



Even though the heading already identifies the build status, this makes it so that the link to CI is somewhat consistent with GitHub UX:
![gh-interface](https://user-images.githubusercontent.com/3999598/181798554-408442df-2641-4669-bebe-c01a0211e204.png)

~Having "[View in CI](https://channable.semaphoreci.com/workflows/c40f133f-02f0-47ca-bd15-df0d24c10c9b?pipeline_id=dd100824-9db3-4fb8-8d63-4e56ce85ee5a) | [e711b80](https://github.com/channable/hoff/commit/42d0af0a66d227de260fb3561f0cc57f91dcb1e4)" looked a bit weird now that the commit hash is present.~ [Not applicable anymore.](https://github.com/channable/hoff/pull/146#discussion_r934199978)
