### PR TITLE
Ignore builds on other branches

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ to simulate those:
 
     $ ./tools/comment deckard 31337 @hoffbot merge
 
-	$ ./tools/build-status c033170123456789abcdef0123456789abcdef01
+	$ ./tools/build-status 31337 c033170123456789abcdef0123456789abcdef01
 
 [Comment]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
 [build status]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#status

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -83,10 +83,11 @@ mapCommitStatus status murl = case status of
 
 eventFromCommitStatusPayload :: CommitStatusPayload -> Logic.Event
 eventFromCommitStatusPayload payload =
-  let sha    = Github.sha    (payload :: CommitStatusPayload)
-      status = Github.status (payload :: CommitStatusPayload)
-      url    = Github.url    (payload :: CommitStatusPayload)
-  in  Logic.BuildStatusChanged sha (mapCommitStatus status url)
+  let sha      = Github.sha    (payload :: CommitStatusPayload)
+      status   = Github.status (payload :: CommitStatusPayload)
+      url      = Github.url    (payload :: CommitStatusPayload)
+      branches = Github.branches (payload :: CommitStatusPayload)
+  in  Logic.BuildStatusChanged branches sha (mapCommitStatus status url)
 
 convertGithubEvent :: Github.WebhookEvent -> Maybe Logic.Event
 convertGithubEvent event = case event of

--- a/src/Github.hs
+++ b/src/Github.hs
@@ -91,7 +91,8 @@ data CommitStatusPayload = CommitStatusPayload {
   repository :: Text,         -- Corresponds to "repository.name".
   status     :: CommitStatus, -- Corresponds to "action".
   url        :: Maybe Text,   -- Corresponds to "target_url".
-  sha        :: Sha           -- Corresponds to "sha".
+  sha        :: Sha,          -- Corresponds to "sha".
+  branches   :: [Branch]      -- Corresponds to "branches[*].name".
 } deriving (Eq, Show)
 
 instance FromJSON PullRequestAction where
@@ -168,6 +169,7 @@ instance FromJSON CommitStatusPayload where
     <*> (v .: "state")
     <*> (v .: "target_url")
     <*> (v .: "sha")
+    <*> ((v .: "branches") >>= traverse (.: "name"))
   parseJSON nonObject = typeMismatch "status payload" nonObject
 
 -- Note that GitHub calls pull requests "issues" for the sake of comments: the

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -44,6 +44,7 @@ module Project
   updatePullRequest,
   updatePullRequestM,
   updatePullRequests,
+  updatePullRequestsWithId,
   getOwners,
   wasIntegrationAttemptFor,
   MergeWindow(..))
@@ -259,6 +260,10 @@ updatePullRequests f state = state {
   pullRequests = IntMap.map f $ pullRequests state
 }
 
+updatePullRequestsWithId :: (PullRequestId -> PullRequest -> PullRequest) -> ProjectState -> ProjectState
+updatePullRequestsWithId f state = state {
+  pullRequests = IntMap.mapWithKey (f . PullRequestId) $ pullRequests state
+}
 -- Marks the pull request as approved by somebody or nobody.
 setApproval :: PullRequestId -> Maybe Approval -> ProjectState -> ProjectState
 setApproval pr newApproval = updatePullRequest pr changeApproval

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -395,7 +395,7 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Add Leon test results" "deckard",
             Logic.CommentAdded pr4 "rachael" "@bot merge",
-            Logic.BuildStatusChanged c4 BuildSucceeded
+            Logic.BuildStatusChanged [Branch "integration/4"] c4 BuildSucceeded
           ]
       history `shouldBe`
         [ "* c4"
@@ -424,7 +424,7 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Add Leon test results" "deckard",
             Logic.CommentAdded pr4 "rachael" "@bot merge",
-            Logic.BuildStatusChanged c4 (BuildFailed Nothing)
+            Logic.BuildStatusChanged [Branch "integration/4"] c4 (BuildFailed Nothing)
           ]
       -- the build failed, so master's history is unchanged
       -- ... and the integration/4 branch is kept for inpection of the CI build
@@ -451,7 +451,7 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Deploy tests!" "deckard",
             Logic.CommentAdded pr4 "rachael" "@bot merge and tag",
-            Logic.BuildStatusChanged c4 BuildSucceeded
+            Logic.BuildStatusChanged [Branch "integration/4"] c4 BuildSucceeded
           ]
       history `shouldBe`
         [ "* c4"
@@ -505,7 +505,7 @@ eventLoopSpec = parallel $ do
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged [Branch "integration/4"] rebasedSha BuildSucceeded]
 
       history `shouldBe`
         [ "*   Merge #4"
@@ -563,7 +563,7 @@ eventLoopSpec = parallel $ do
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha BuildSucceeded]
 
       history `shouldBe`
         [ "*   Merge #6"
@@ -600,7 +600,7 @@ eventLoopSpec = parallel $ do
 
         let [rebasedSha] = integrationShas state
 
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha BuildSucceeded]
 
       history `shouldBe`
         [ "*   Merge #6"
@@ -658,7 +658,7 @@ eventLoopSpec = parallel $ do
 
         let [rebasedSha] = integrationShas state
 
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha BuildSucceeded]
 
       history `shouldBe`
         [ "*   Merge #6"
@@ -722,12 +722,12 @@ eventLoopSpec = parallel $ do
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha BuildSucceeded]
 
         -- Repeat for the other pull request, which should be the candidate by
         -- now.
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged [Branch "integration/4"] rebasedSha' BuildSucceeded]
 
       history `shouldBe`
         [ "* c4"
@@ -761,10 +761,10 @@ eventLoopSpec = parallel $ do
 
         let [rebasedSha] = integrationShas state
 
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha BuildSucceeded]
 
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged [Branch "integration/4"] rebasedSha' BuildSucceeded]
 
       history `shouldBe`
         [ "* c4"
@@ -886,7 +886,7 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha BuildSucceeded]
 
         -- The push should have failed, hence there should still be an
         -- integration candidate.
@@ -894,7 +894,7 @@ eventLoopSpec = parallel $ do
 
         -- Again notify build success, now for the new commit.
         let [rebasedSha'] = integrationShas state'
-        state'' <- runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        state'' <- runLoop state' [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been
         -- integrated properly, so there should not be a new candidate.
@@ -937,11 +937,11 @@ eventLoopSpec = parallel $ do
         git ["push", "origin", refSpec (c4, masterBranch)]
 
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been
         -- integrated properly, version should be incremented only once
@@ -1009,11 +1009,11 @@ eventLoopSpec = parallel $ do
         git ["push", "origin", refSpec (Git.TagName "v2")]
 
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged [Branch "integration/6"] rebasedSha' BuildSucceeded]
 
         -- After the second build success, the pull request should have been integrated properly,
         -- version should be incremented only once, and follow version that appeared in the meantime
@@ -1078,7 +1078,7 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let [rebasedSha] = integrationShas state
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged [Branch "integration/8"] rebasedSha BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
       -- now c8 is the last commit, and there are no others. Note that if the
@@ -1118,11 +1118,11 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged [Branch "integration/8"] rebasedSha BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged [Branch "integration/8"] rebasedSha' BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
       -- now c8 is the last commit, and there are no others. This time c4 and c5
@@ -1168,7 +1168,7 @@ eventLoopSpec = parallel $ do
         -- tell the loop that building the commit succeeded.
 
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged [Branch "integration/8"] rebasedSha BuildSucceeded]
 
         --The pull request should not be integrated. Moreover, the presence of
         --orphan fixups should make the PR ineligible for being a candidate for integration.
@@ -1210,7 +1210,7 @@ eventLoopSpec = parallel $ do
 
         state' <- runLoop state
           [
-            Logic.BuildStatusChanged rebasedSha BuildSucceeded,
+            Logic.BuildStatusChanged [Branch "integration/8"] rebasedSha BuildSucceeded,
             Logic.CommentAdded pr6 "rachael" "@bot merge"
           ]
 

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -424,7 +424,7 @@ main = hspec $ do
 
     it "handles a build status change of the integration candidate" $ do
       let
-        event  = BuildStatusChanged (Sha "84c") Project.BuildSucceeded
+        event  = BuildStatusChanged [Branch "testing/1"] (Sha "84c") Project.BuildSucceeded
         state  = candidateState (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "johanna" "deckard" (Sha "84c")
         state' = fst $ runAction $ handleEventTest event state
         pr     = fromJust $ Project.lookupPullRequest (PullRequestId 1) state'
@@ -433,7 +433,7 @@ main = hspec $ do
     it "ignores a build status change for commits that are not the integration candidate" $ do
       let
         event0 = PullRequestOpened (PullRequestId 2) (Branch "p") masterBranch (Sha "0ad") "title" "harry"
-        event1 = BuildStatusChanged (Sha "0ad") Project.BuildSucceeded
+        event1 = BuildStatusChanged [Branch "testing/1"] (Sha "0ad") Project.BuildSucceeded
         state  = candidateState (PullRequestId 1) (Branch "p") masterBranch (Sha "a38") "harry" "deckard" (Sha "84c")
         state' = fst $ runAction $ handleEventsTest [event0, event1] state
         pr1    = fromJust $ Project.lookupPullRequest (PullRequestId 1) state'
@@ -1325,8 +1325,8 @@ main = hspec $ do
           $ Project.emptyProjectState
         events =
           [ CommentAdded (PullRequestId 1) "deckard" "@bot merge"
-          , BuildStatusChanged (Sha "b71") Project.BuildPending
-          , BuildStatusChanged (Sha "b71") Project.BuildSucceeded
+          , BuildStatusChanged [Branch "testing/1"] (Sha "b71") Project.BuildPending
+          , BuildStatusChanged [Branch "testing/1"] (Sha "b71") Project.BuildSucceeded
           ]
         -- For this test, the first integration succeeds. Then we push, which
         -- fails. Then we try to integrate again, but that fails.
@@ -1415,9 +1415,9 @@ main = hspec $ do
           $ Project.emptyProjectState
         events =
           [ CommentAdded (PullRequestId 1) "deckard" "@bot merge"
-          , BuildStatusChanged (Sha "b71") Project.BuildPending
-          , BuildStatusChanged (Sha "b71") (Project.BuildStarted "https://status.example.com/b71")
-          , BuildStatusChanged (Sha "b71") $ Project.BuildFailed $ Just $ pack "https://example.com/build-status"
+          , BuildStatusChanged [Branch "testing/1"] (Sha "b71") Project.BuildPending
+          , BuildStatusChanged [Branch "testing/1"] (Sha "b71") (Project.BuildStarted "https://status.example.com/b71")
+          , BuildStatusChanged [Branch "testing/1"] (Sha "b71") $ Project.BuildFailed $ Just $ pack "https://example.com/build-status"
             -- User summons bot again because CI failed for an external reason.
           , CommentAdded (PullRequestId 1) "deckard" "@bot merge"
           -- GitHub notifies Hoff of new comments sent by Hoff:
@@ -1683,28 +1683,29 @@ main = hspec $ do
           , status     = status
           , url        = Just "https://travis-ci.org/rachael/owl/builds/1982"
           , sha        = Sha "b26354"
+          , branches   = [Branch "some-branch"]
           }
 
     it "converts a commit status pending event" $ do
       let payload = testCommitStatusPayload Github.Pending
           Just event = convertGithubEvent $ Github.CommitStatus payload
-      event `shouldBe` (BuildStatusChanged (Sha "b26354") (Project.BuildStarted "https://travis-ci.org/rachael/owl/builds/1982"))
+      event `shouldBe` (BuildStatusChanged [Branch "some-branch"] (Sha "b26354") (Project.BuildStarted "https://travis-ci.org/rachael/owl/builds/1982"))
 
     it "converts a commit status success event" $ do
       let payload = testCommitStatusPayload Github.Success
           Just event = convertGithubEvent $ Github.CommitStatus payload
-      event `shouldBe` (BuildStatusChanged (Sha "b26354") Project.BuildSucceeded)
+      event `shouldBe` (BuildStatusChanged [Branch "some-branch"] (Sha "b26354") Project.BuildSucceeded)
 
     it "converts a commit status failure event" $ do
       let payload = testCommitStatusPayload Github.Failure
           Just event = convertGithubEvent $ Github.CommitStatus payload
-      event `shouldBe` (BuildStatusChanged (Sha "b26354") $ Project.BuildFailed $ Just $ pack "https://travis-ci.org/rachael/owl/builds/1982")
+      event `shouldBe` (BuildStatusChanged [Branch "some-branch"] (Sha "b26354") $ Project.BuildFailed $ Just $ pack "https://travis-ci.org/rachael/owl/builds/1982")
 
     it "converts a commit status error event" $ do
       let payload = testCommitStatusPayload Github.Error
           Just event = convertGithubEvent $ Github.CommitStatus payload
       -- The error and failure statuses are both converted to "failed".
-      event `shouldBe` (BuildStatusChanged (Sha "b26354") $ Project.BuildFailed $ Just $ pack "https://travis-ci.org/rachael/owl/builds/1982")
+      event `shouldBe` (BuildStatusChanged [Branch "some-branch"] (Sha "b26354") $ Project.BuildFailed $ Just $ pack "https://travis-ci.org/rachael/owl/builds/1982")
 
   describe "ProjectState" $ do
 
@@ -1732,6 +1733,64 @@ main = hspec $ do
       state `shouldBe` state'
       removeFile fname
 
+    it "ignores builds on other branches" $ do
+      let
+        state = Project.insertPullRequest
+                  (PullRequestId 360)
+                  (Branch "add-package")
+                  masterBranch
+                  (Sha "c6b")
+                  "Three hundred and sixtieth PR"
+                  (Username "tyrell")
+              $ Project.emptyProjectState
+        events =
+          [ CommentAdded (PullRequestId 360) "deckard" "@someone Thanks for your review."
+          , CommentAdded (PullRequestId 360) "deckard" "@bot merge"
+
+          -- same status, ignored:
+          , BuildStatusChanged [Branch "testing/360"] (Sha "c6b") Project.BuildPending
+          -- correct branch but different sha (old build?), ignored
+          , BuildStatusChanged [Branch "testing/360"] (Sha "ab0") (Project.BuildStarted "ci.example.com/diff-sha")
+          -- correct sha but different branch
+          , BuildStatusChanged [Branch "add-package"] (Sha "c6b") (Project.BuildStarted "ci.exmaple.com/diff-branch")
+
+          -- unrecognized command to act as a separator
+          , CommentAdded (PullRequestId 360) "deckard" "@bot do something"
+
+          -- correct branch and sha
+          , BuildStatusChanged [Branch "testing/360"] (Sha "c6b") (Project.BuildStarted "ci.example.com/correct")
+
+          -- correct branch but different sha (old build?), ignored
+          , BuildStatusChanged [Branch "testing/360"] (Sha "ab0") (Project.BuildFailed (Just "ci.example.com/diff-sha"))
+          -- correct sha but different branch
+          -- older versions would fail to merge this PR, even though it's "official" build passed
+          , BuildStatusChanged [Branch "add-package"] (Sha "c6b") (Project.BuildFailed (Just "ci.exmaple.com/diff-branch"))
+          -- correct branch and sha
+          , BuildStatusChanged [Branch "testing/360"] (Sha "c6b") Project.BuildSucceeded
+          ]
+        results = defaultResults{resultIntegrate = [Right (Sha "c6b")]} -- fastforward
+        run = runActionCustom results
+        actions = snd $ run $ handleEventsTest events state
+      actions `shouldBe`
+        [ AIsReviewer "deckard"
+        -- comment: @bot merge!
+        , ALeaveComment (PullRequestId 360)
+                        "Pull request approved for merge by @deckard, rebasing now."
+        , ATryIntegrate "Merge #360: Three hundred and sixtieth PR\n\n\
+                        \Approved-by: deckard\n\
+                        \Auto-deploy: false\n"
+                        (PullRequestId 360, Branch "refs/pull/360/head", Sha "c6b")
+                        False
+        , ALeaveComment (PullRequestId 360) "Rebased as c6b, waiting for CI …"
+        -- incorrect CI link webhooks arrive
+        -- comment: @bot do something!
+        , ALeaveComment (PullRequestId 360) "`do something` was not recognized as a valid command."
+        -- correct CI link webhook arrives
+        , ALeaveComment (PullRequestId 360) "[CI job](ci.example.com/correct) started."
+        , ATryPromote (Branch "add-package") (Sha "c6b")
+        , ACleanupTestBranch (PullRequestId 360)
+        ]
+
     it "handles a sequence of merges: success, success, success" $ do
       -- An afternoon of work on PRs:
       -- * three PRs are merged and approved in order
@@ -1747,32 +1806,32 @@ main = hspec $ do
           $ Project.insertPullRequest (PullRequestId 3) (Branch "trd") masterBranch (Sha "ef3") "Third PR"  (Username "rachael")
           $ Project.emptyProjectState
         events =
-          [ BuildStatusChanged (Sha "ab1") (Project.BuildSucceeded) -- PR#1 sha, ignored
+          [ BuildStatusChanged [Branch "fst"] (Sha "ab1") (Project.BuildSucceeded) -- PR#1 sha, ignored
           , CommentAdded (PullRequestId 1) "deckard" "@someone Thanks for your review."
           , CommentAdded (PullRequestId 1) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 1) "bot" "Pull request approved for merge, rebasing now."
           , CommentAdded (PullRequestId 1) "bot" "Rebased as 1ab, waiting for CI …"
           , CommentAdded (PullRequestId 2) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 2) "bot" "Pull request approved for merge behind 1 PR."
-          , BuildStatusChanged (Sha "ef3") (Project.BuildSucceeded) -- PR#3 sha, ignored
-          , BuildStatusChanged (Sha "1ab") (Project.BuildPending) -- same status, ignored
-          , BuildStatusChanged (Sha "1ab") (Project.BuildStarted "example.com/1ab")
-          , BuildStatusChanged (Sha "1ab") (Project.BuildStarted "example.com/1ab") -- dup!
+          , BuildStatusChanged [Branch "trd"] (Sha "ef3") (Project.BuildSucceeded) -- PR#3 sha, ignored
+          , BuildStatusChanged [Branch "testing/1"] (Sha "1ab") (Project.BuildPending) -- same status, ignored
+          , BuildStatusChanged [Branch "testing/1"] (Sha "1ab") (Project.BuildStarted "example.com/1ab")
+          , BuildStatusChanged [Branch "testing/1"] (Sha "1ab") (Project.BuildStarted "example.com/1ab") -- dup!
           , CommentAdded (PullRequestId 1) "bot" "[CI job](example.com/1ab) started."
           , CommentAdded (PullRequestId 3) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 3) "bot" "Pull request approved for merge behind 2 PRs."
-          , BuildStatusChanged (Sha "cd2") (Project.BuildSucceeded) -- PR#2 sha, ignored
-          , BuildStatusChanged (Sha "1ab") (Project.BuildSucceeded) -- PR#1
+          , BuildStatusChanged [Branch "snd"] (Sha "cd2") (Project.BuildSucceeded) -- PR#2 sha, ignored
+          , BuildStatusChanged [Branch "testing/1"] (Sha "1ab") (Project.BuildSucceeded) -- PR#1
           , PullRequestClosed (PullRequestId 1)
           , CommentAdded (PullRequestId 2) "bot" "Rebased as 2bc, waiting for CI …"
-          , BuildStatusChanged (Sha "2bc") (Project.BuildStarted "example.com/2bc")
+          , BuildStatusChanged [Branch "testing/2"] (Sha "2bc") (Project.BuildStarted "example.com/2bc")
           , CommentAdded (PullRequestId 2) "bot" "[CI job](example.com/2bc) started."
-          , BuildStatusChanged (Sha "36a") (Project.BuildSucceeded) -- arbitrary sha, ignored
-          , BuildStatusChanged (Sha "2bc") (Project.BuildSucceeded) -- PR#2
+          , BuildStatusChanged [Branch "testing/3"] (Sha "36a") (Project.BuildSucceeded) -- arbitrary sha, ignored
+          , BuildStatusChanged [Branch "testing/2"] (Sha "2bc") (Project.BuildSucceeded) -- PR#2
           , PullRequestClosed (PullRequestId 2)
           , CommentAdded (PullRequestId 3) "bot" "Rebased as 3cd, waiting for CI …"
-          , BuildStatusChanged (Sha "3cd") (Project.BuildStarted "example.com/3cd")
-          , BuildStatusChanged (Sha "3cd") (Project.BuildSucceeded) -- PR#3
+          , BuildStatusChanged [Branch "testing/3"] (Sha "3cd") (Project.BuildStarted "example.com/3cd")
+          , BuildStatusChanged [Branch "testing/3"] (Sha "3cd") (Project.BuildSucceeded) -- PR#3
           , PullRequestClosed (PullRequestId 3)
           ]
         -- For this test, we assume all integrations and pushes succeed.
@@ -1837,32 +1896,32 @@ main = hspec $ do
           $ Project.insertPullRequest (PullRequestId 7) (Branch "sth") masterBranch (Sha "ef7") "Seventh PR"  (Username "rachael")
           $ Project.emptyProjectState
         events =
-          [ BuildStatusChanged (Sha "ab9") (Project.BuildSucceeded) -- PR#9 sha, ignored
+          [ BuildStatusChanged [Branch "nth"] (Sha "ab9") (Project.BuildSucceeded) -- PR#9 sha, ignored
           , CommentAdded (PullRequestId 9) "deckard" "@someone Thanks for your review."
           , CommentAdded (PullRequestId 9) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 9) "bot" "Pull request approved for merge, rebasing now."
           , CommentAdded (PullRequestId 9) "bot" "Rebased as 1ab, waiting for CI …"
           , CommentAdded (PullRequestId 8) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 8) "bot" "Pull request approved for merge behind 1 PR."
-          , BuildStatusChanged (Sha "ef7") (Project.BuildSucceeded) -- PR#7 sha, ignored
-          , BuildStatusChanged (Sha "1ab") (Project.BuildPending) -- same status, ignored
-          , BuildStatusChanged (Sha "1ab") (Project.BuildStarted "example.com/1ab")
+          , BuildStatusChanged [Branch "sth"] (Sha "ef7") (Project.BuildSucceeded) -- PR#7 sha, ignored
+          , BuildStatusChanged [Branch "testing/9"] (Sha "1ab") (Project.BuildPending) -- same status, ignored
+          , BuildStatusChanged [Branch "testing/9"] (Sha "1ab") (Project.BuildStarted "example.com/1ab")
           , CommentAdded (PullRequestId 9) "bot" "[CI job](example.com/1ab) started."
           , CommentAdded (PullRequestId 7) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 7) "bot" "Pull request approved for merge behind 2 PRs."
-          , BuildStatusChanged (Sha "cd8") (Project.BuildSucceeded) -- PR#8 sha, ignored
-          , BuildStatusChanged (Sha "1ab") (Project.BuildSucceeded) -- PR#9
+          , BuildStatusChanged [Branch "eth"] (Sha "cd8") (Project.BuildSucceeded) -- PR#8 sha, ignored
+          , BuildStatusChanged [Branch "testing/9"] (Sha "1ab") (Project.BuildSucceeded)
           , PullRequestClosed (PullRequestId 9)
           , CommentAdded (PullRequestId 8) "bot" "Rebased as 2bc, waiting for CI …"
-          , BuildStatusChanged (Sha "2bc") (Project.BuildStarted "example.com/2bc")
+          , BuildStatusChanged [Branch "testing/8"] (Sha "2bc") (Project.BuildStarted "example.com/2bc")
           , CommentAdded (PullRequestId 8) "bot" "[CI job](example.com/2bc) started."
-          , BuildStatusChanged (Sha "36a") (Project.BuildSucceeded) -- arbitrary sha, ignored
-          , BuildStatusChanged (Sha "2bc") (Project.BuildFailed (Just "example.com/2bc")) -- PR#8
-          , BuildStatusChanged (Sha "2bc") (Project.BuildFailed (Just "example.com/2bc")) -- dup!
+          , BuildStatusChanged [Branch "other"] (Sha "36a") (Project.BuildSucceeded) -- arbitrary sha, ignored
+          , BuildStatusChanged [Branch "testing/8"] (Sha "2bc") (Project.BuildFailed (Just "example.com/2bc")) -- PR#8
+          , BuildStatusChanged [Branch "testing/8"] (Sha "2bc") (Project.BuildFailed (Just "example.com/2bc")) -- dup!
           , CommentAdded (PullRequestId 8) "bot" "The build failed: example.com/2bc"
           , CommentAdded (PullRequestId 7) "bot" "Rebased as 3cd, waiting for CI …"
-          , BuildStatusChanged (Sha "3cd") (Project.BuildStarted "example.com/3cd")
-          , BuildStatusChanged (Sha "3cd") (Project.BuildSucceeded) -- testing build passed on PR#7
+          , BuildStatusChanged [Branch "testing/7"] (Sha "3cd") (Project.BuildStarted "example.com/3cd")
+          , BuildStatusChanged [Branch "testing/7"] (Sha "3cd") (Project.BuildSucceeded) -- testing build passed on PR#7
           , PullRequestClosed (PullRequestId 7)
           ]
         -- For this test, we assume all integrations and pushes succeed.

--- a/tools/send-webhook
+++ b/tools/send-webhook
@@ -10,7 +10,7 @@
 #
 # $ ./tools/comment deckard 1337 @hoffbot merge
 #
-# $ ./tools/build-status c033170123456789abcdef0123456789abcdef01
+# $ ./tools/build-status 1337 c033170123456789abcdef0123456789abcdef01
 #
 # The files ./tools/comment and ./tools/build-status are set up as symlinks.
 #
@@ -94,6 +94,9 @@ cat <<JSON
 	},
 	"sha": "$commit",
 	"state": "$state",
+	"branches": [
+		{ "name": "$branch/$number" }
+	],
 	"target_url": $target
 }
 JSON
@@ -102,6 +105,7 @@ JSON
 secret=$(get secret)
 owner=$(get owner)
 repository=$(get repository)
+branch=$(get testBranch)
 
 [ -n "$secret" ]     || errxit "could not parse secret from config.json"
 [ -n "$owner"  ]     || errxit "could not parse owner from config.json"
@@ -122,11 +126,13 @@ comment)
 	;;
 build-status)
 	event=
-	commit="$1"
-	state="$2"
-	target="$3"
+	number="$1"
+	commit="$2"
+	state="$3"
+	target="$4"
 
-	[ -n "$commit" ] || errxit "Full commit sha should be provided as the 1st argument"
+	[ -n "$number" ] || errxit "PR number should be provided as the 1st argument"
+	[ -n "$commit" ] || errxit "Full commit sha should be provided as the 2nd argument"
 	[ -n "$state" ] || state=success
 
 	# If this is a URL make sure it has quote marks, if null make sure it doesn't.


### PR DESCRIPTION
closes: #147 

If there are two builds on different branches but with the same hash, GitHub reports these at least twice!  (Once per branch.)  This makes it so that we only consider build status changes on the actual relevant testing branch.  There's a detailed explanation [here](https://github.com/channable/hoff/issues/147#issuecomment-1202539768).

* [x] parse the branches list sent by GitHub
* [x] update send-webhook to include the list of branches
* [x] ignore other branches on BuildStatusChanged
* [x] add specific test with repeated build status update for a sha but different branches.  The status for the other branch should be ignore
* [x] mark for review
* [x] amend if needed
* [x] merge