### PR TITLE
Improve markdown in comments for ``CI job started`` and ``build failed``

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -863,7 +863,7 @@ describeStatus prId pr state = case Pr.classifyPullRequest pr of
                                  \ I will retry rebasing automatically when the queue clears."
   PrStatusFailedBuild url -> case Pr.unfailedIntegratedPullRequestsBefore pr state of
     [] -> case url of
-          Just url' -> format "The build failed: {}\n\
+          Just url' -> format "The [build failed ❌]({})\n\
                               \If this is the result of a flaky test, \
                               \close and reopen the PR, then tag me again.\n\
                               \Otherwise, push a new commit and tag me again." [url']

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -838,7 +838,7 @@ describeStatus prId pr state = case Pr.classifyPullRequest pr of
                                                   , " behind ", prettyPullRequestIds train
                                                   , ", waiting for CI …"
                                                   ]
-  PrStatusBuildStarted url -> Text.concat ["[CI job](", url, ") started."]
+  PrStatusBuildStarted url -> Text.concat ["[CI job 🟡](", url, ") started."]
   PrStatusIntegrated -> "The build succeeded."
   PrStatusIncorrectBaseBranch -> "Merge rejected: the target branch must be the integration branch."
   PrStatusWrongFixups -> "Pull request cannot be integrated as it contains fixup commits that do not belong to any other commits."

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1469,7 +1469,7 @@ main = hspec $ do
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a39") [] False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
-        , ALeaveComment (PullRequestId 1) "[CI job](https://status.example.com/b71) started."
+        , ALeaveComment (PullRequestId 1) "[CI job 🟡](https://status.example.com/b71) started."
         , ALeaveComment (PullRequestId 1) "The build failed: https://example.com/build-status\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
         , AIsReviewer "deckard"
           -- Nothing has changed for the bot because b71 has already failed, so
@@ -1780,7 +1780,7 @@ main = hspec $ do
           , CommentAdded (PullRequestId 12) "bot" "Pull request approved for merge, rebasing now."
           , CommentAdded (PullRequestId 12) "bot" "Rebased as 1b2, waiting for CI …"
           , BuildStatusChanged (Sha "1b2") (Project.BuildStarted "example.com/1b2")
-          , CommentAdded (PullRequestId 1) "bot" "[CI job](example.com/1b2) started."
+          , CommentAdded (PullRequestId 1) "bot" "[CI job 🟡](example.com/1b2) started."
           , BuildStatusChanged (Sha "1b2") (Project.BuildFailed (Just "example.com/1b2"))
           , BuildStatusChanged (Sha "1b2") Project.BuildPending -- ignored
           , BuildStatusChanged (Sha "1b2") (Project.BuildStarted "example.com/1b2") -- ignored
@@ -1798,7 +1798,7 @@ main = hspec $ do
                         []
                         False
         , ALeaveComment (PullRequestId 12) "Rebased as 1b2, waiting for CI …"
-        , ALeaveComment (PullRequestId 12) "[CI job](example.com/1b2) started."
+        , ALeaveComment (PullRequestId 12) "[CI job 🟡](example.com/1b2) started."
         , ALeaveComment (PullRequestId 12) "The build failed: example.com/1b2\n\
                                            \If this is the result of a flaky test, \
                                            \close and reopen the PR, then tag me again.\n\
@@ -1821,7 +1821,7 @@ main = hspec $ do
           , CommentAdded (PullRequestId 12) "bot" "Pull request approved for merge, rebasing now."
           , CommentAdded (PullRequestId 12) "bot" "Rebased as 1b2, waiting for CI …"
           , BuildStatusChanged (Sha "1b2") (Project.BuildStarted "example.com/1b2")
-          , CommentAdded (PullRequestId 1) "bot" "[CI job](example.com/1b2) started."
+          , CommentAdded (PullRequestId 1) "bot" "[CI job 🟡](example.com/1b2) started."
           , BuildStatusChanged (Sha "1b2") Project.BuildSucceeded
           , BuildStatusChanged (Sha "1b2") Project.BuildPending -- ignored
           , BuildStatusChanged (Sha "1b2") (Project.BuildStarted "example.com/1b2") -- ignored
@@ -1838,7 +1838,7 @@ main = hspec $ do
                         []
                         False
         , ALeaveComment (PullRequestId 12) "Rebased as 1b2, waiting for CI …"
-        , ALeaveComment (PullRequestId 12) "[CI job](example.com/1b2) started."
+        , ALeaveComment (PullRequestId 12) "[CI job 🟡](example.com/1b2) started."
         , ATryPromote (Branch "tth") (Sha "1b2")
         , ACleanupTestBranch (PullRequestId 12)
         ]
@@ -2555,7 +2555,7 @@ main = hspec $ do
           , BuildStatusChanged (Sha "1ab") (Project.BuildPending) -- same status, ignored
           , BuildStatusChanged (Sha "1ab") (Project.BuildStarted "example.com/1ab")
           , BuildStatusChanged (Sha "1ab") (Project.BuildStarted "example.com/1ab") -- dup!
-          , CommentAdded (PullRequestId 1) "bot" "[CI job](example.com/1ab) started."
+          , CommentAdded (PullRequestId 1) "bot" "[CI job 🟡](example.com/1ab) started."
           , CommentAdded (PullRequestId 3) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 3) "bot" "Pull request approved for merge behind 2 PRs."
           , BuildStatusChanged (Sha "cd2") (Project.BuildSucceeded) -- PR#2 sha, ignored
@@ -2563,7 +2563,7 @@ main = hspec $ do
           , PullRequestClosed (PullRequestId 1)
           , CommentAdded (PullRequestId 2) "bot" "Rebased as 2bc, waiting for CI …"
           , BuildStatusChanged (Sha "2bc") (Project.BuildStarted "example.com/2bc")
-          , CommentAdded (PullRequestId 2) "bot" "[CI job](example.com/2bc) started."
+          , CommentAdded (PullRequestId 2) "bot" "[CI job 🟡](example.com/2bc) started."
           , BuildStatusChanged (Sha "36a") (Project.BuildSucceeded) -- arbitrary sha, ignored
           , BuildStatusChanged (Sha "2bc") (Project.BuildSucceeded) -- PR#2
           , PullRequestClosed (PullRequestId 2)
@@ -2600,7 +2600,7 @@ main = hspec $ do
                         [PullRequestId 1]
                         False
         , ALeaveComment (PullRequestId 2) "Speculatively rebased as 2bc behind #1, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "[CI job](example.com/1ab) started."
+        , ALeaveComment (PullRequestId 1) "[CI job 🟡](example.com/1ab) started."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3)
                         "Pull request approved for merge by @deckard, \
@@ -2614,10 +2614,10 @@ main = hspec $ do
         , ALeaveComment (PullRequestId 3) "Speculatively rebased as 3cd behind #1 and #2, waiting for CI …"
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
-        , ALeaveComment (PullRequestId 2) "[CI job](example.com/2bc) started."
+        , ALeaveComment (PullRequestId 2) "[CI job 🟡](example.com/2bc) started."
         , ATryPromote (Branch "snd") (Sha "2bc")
         , ACleanupTestBranch (PullRequestId 2)
-        , ALeaveComment (PullRequestId 3) "[CI job](example.com/3cd) started."
+        , ALeaveComment (PullRequestId 3) "[CI job 🟡](example.com/3cd) started."
         , ATryPromote (Branch "trd") (Sha "3cd")
         , ACleanupTestBranch (PullRequestId 3)
         ]
@@ -2647,7 +2647,7 @@ main = hspec $ do
           , BuildStatusChanged (Sha "ef7") (Project.BuildSucceeded) -- PR#7 sha, ignored
           , BuildStatusChanged (Sha "1ab") (Project.BuildPending) -- same status, ignored
           , BuildStatusChanged (Sha "1ab") (Project.BuildStarted "example.com/1ab")
-          , CommentAdded (PullRequestId 9) "bot" "[CI job](example.com/1ab) started."
+          , CommentAdded (PullRequestId 9) "bot" "[CI job 🟡](example.com/1ab) started."
           , CommentAdded (PullRequestId 7) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 7) "bot" "Pull request approved for merge behind 2 PRs."
           , BuildStatusChanged (Sha "cd8") (Project.BuildSucceeded) -- PR#8 sha, ignored
@@ -2655,7 +2655,7 @@ main = hspec $ do
           , PullRequestClosed (PullRequestId 9)
           , CommentAdded (PullRequestId 8) "bot" "Rebased as 2bc, waiting for CI …"
           , BuildStatusChanged (Sha "2bc") (Project.BuildStarted "example.com/2bc")
-          , CommentAdded (PullRequestId 8) "bot" "[CI job](example.com/2bc) started."
+          , CommentAdded (PullRequestId 8) "bot" "[CI job 🟡](example.com/2bc) started."
           , BuildStatusChanged (Sha "3cd") (Project.BuildSucceeded) -- testing build passed on PR#7
           , BuildStatusChanged (Sha "36a") (Project.BuildSucceeded) -- arbitrary sha, ignored
           , BuildStatusChanged (Sha "2bc") (Project.BuildFailed (Just "example.com/2bc")) -- PR#8
@@ -2695,7 +2695,7 @@ main = hspec $ do
                         [PullRequestId 9]
                         False
         , ALeaveComment (PullRequestId 8) "Speculatively rebased as 2bc behind #9, waiting for CI …"
-        , ALeaveComment (PullRequestId 9) "[CI job](example.com/1ab) started."
+        , ALeaveComment (PullRequestId 9) "[CI job 🟡](example.com/1ab) started."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 7)
                         "Pull request approved for merge by @deckard, \
@@ -2709,7 +2709,7 @@ main = hspec $ do
         , ALeaveComment (PullRequestId 7) "Speculatively rebased as 3cd behind #9 and #8, waiting for CI …"
         , ATryPromote (Branch "nth") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 9)
-        , ALeaveComment (PullRequestId 8) "[CI job](example.com/2bc) started."
+        , ALeaveComment (PullRequestId 8) "[CI job 🟡](example.com/2bc) started."
         , ALeaveComment (PullRequestId 8)
                         "The build failed: example.com/2bc\n\
                         \If this is the result of a flaky test, \
@@ -2723,7 +2723,7 @@ main = hspec $ do
                         []
                         False
         , ALeaveComment (PullRequestId 7) "Rebased as 3ef, waiting for CI …"
-        , ALeaveComment (PullRequestId 7) "[CI job](example.com/3ef) started."
+        , ALeaveComment (PullRequestId 7) "[CI job 🟡](example.com/3ef) started."
         , ATryPromote (Branch "sth") (Sha "3ef")
         , ACleanupTestBranch (PullRequestId 7)
         ]
@@ -2755,7 +2755,7 @@ main = hspec $ do
           , BuildStatusChanged (Sha "1ab") (Project.BuildPending) -- same status, ignored
           , BuildStatusChanged (Sha "1ab") (Project.BuildStarted "example.com/1ab")
           , BuildStatusChanged (Sha "1ab") (Project.BuildStarted "example.com/1ab") -- dup!
-          , CommentAdded (PullRequestId 1) "bot" "[CI job](example.com/1ab) started."
+          , CommentAdded (PullRequestId 1) "bot" "[CI job 🟡](example.com/1ab) started."
           , CommentAdded (PullRequestId 3) "deckard" "@bot merge"
           , CommentAdded (PullRequestId 3) "bot" "Pull request approved for merge behind 2 PRs."
           , CommentAdded (PullRequestId 4) "deckard" "@bot merge"
@@ -2765,7 +2765,7 @@ main = hspec $ do
           , PullRequestClosed (PullRequestId 1)
           , CommentAdded (PullRequestId 2) "bot" "Rebased as 2bc, waiting for CI …"
           , BuildStatusChanged (Sha "2bc") (Project.BuildStarted "example.com/2bc")
-          , CommentAdded (PullRequestId 2) "bot" "[CI job](example.com/2bc) started."
+          , CommentAdded (PullRequestId 2) "bot" "[CI job 🟡](example.com/2bc) started."
           , BuildStatusChanged (Sha "36a") (Project.BuildSucceeded) -- arbitrary sha, ignored
           , BuildStatusChanged (Sha "2bc") (Project.BuildSucceeded) -- PR#2
           , PullRequestClosed (PullRequestId 2)
@@ -2806,7 +2806,7 @@ main = hspec $ do
                         [PullRequestId 1]
                         False
         , ALeaveComment (PullRequestId 2) "Speculatively rebased as 2bc behind #1, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "[CI job](example.com/1ab) started."
+        , ALeaveComment (PullRequestId 1) "[CI job 🟡](example.com/1ab) started."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3)
                         "Pull request approved for merge by @deckard, \
@@ -2831,13 +2831,13 @@ main = hspec $ do
         , ALeaveComment (PullRequestId 4) "Speculatively rebased as 4de behind #1, #2 and #3, waiting for CI …"
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
-        , ALeaveComment (PullRequestId 2) "[CI job](example.com/2bc) started."
+        , ALeaveComment (PullRequestId 2) "[CI job 🟡](example.com/2bc) started."
         , ATryPromote (Branch "snd") (Sha "2bc")
         , ACleanupTestBranch (PullRequestId 2)
-        , ALeaveComment (PullRequestId 3) "[CI job](example.com/3cd) started."
+        , ALeaveComment (PullRequestId 3) "[CI job 🟡](example.com/3cd) started."
         , ATryPromote (Branch "trd") (Sha "3cd")
         , ACleanupTestBranch (PullRequestId 3)
-        , ALeaveComment (PullRequestId 4) "[CI job](example.com/4de) started."
+        , ALeaveComment (PullRequestId 4) "[CI job 🟡](example.com/4de) started."
         , ATryPromote (Branch "fth") (Sha "4de")
         , ACleanupTestBranch (PullRequestId 4)
         ]

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1457,8 +1457,8 @@ main = hspec $ do
             -- User summons bot again because CI failed for an external reason.
           , CommentAdded (PullRequestId 1) "deckard" "@bot merge"
           -- GitHub notifies Hoff of new comments sent by Hoff:
-          , CommentAdded (PullRequestId 1) "bot" "The build failed: https://example.com/build-status\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
-          , CommentAdded (PullRequestId 1) "bot" "The build failed: https://example.com/build-status\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
+          , CommentAdded (PullRequestId 1) "bot" "The [build failed ❌](https://example.com/build-status)\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
+          , CommentAdded (PullRequestId 1) "bot" "The [build failed ❌](https://example.com/build-status)\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
           ]
         results = defaultResults { resultIntegrate = [Right (Sha "b71")] }
         (state', actions) = runActionCustom results $ handleEventsTest events state
@@ -1470,11 +1470,11 @@ main = hspec $ do
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a39") [] False
         , ALeaveComment (PullRequestId 1) "Rebased as b71, waiting for CI \x2026"
         , ALeaveComment (PullRequestId 1) "[CI job 🟡](https://status.example.com/b71) started."
-        , ALeaveComment (PullRequestId 1) "The build failed: https://example.com/build-status\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
+        , ALeaveComment (PullRequestId 1) "The [build failed ❌](https://example.com/build-status)\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
         , AIsReviewer "deckard"
           -- Nothing has changed for the bot because b71 has already failed, so
           -- it doesn't retry, but reports the correct state.
-        , ALeaveComment (PullRequestId 1) "The build failed: https://example.com/build-status\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
+        , ALeaveComment (PullRequestId 1) "The [build failed ❌](https://example.com/build-status)\nIf this is the result of a flaky test, close and reopen the PR, then tag me again.\nOtherwise, push a new commit and tag me again."
         ]
 
       -- the pull request should start and end without needing feedback
@@ -1799,11 +1799,11 @@ main = hspec $ do
                         False
         , ALeaveComment (PullRequestId 12) "Rebased as 1b2, waiting for CI …"
         , ALeaveComment (PullRequestId 12) "[CI job 🟡](example.com/1b2) started."
-        , ALeaveComment (PullRequestId 12) "The build failed: example.com/1b2\n\
+        , ALeaveComment (PullRequestId 12) "The [build failed ❌](example.com/1b2)\n\
                                            \If this is the result of a flaky test, \
                                            \close and reopen the PR, then tag me again.\n\
                                            \Otherwise, push a new commit and tag me again."
-        , ALeaveComment (PullRequestId 12) "The build failed: example.com/alt/1b2\n\
+        , ALeaveComment (PullRequestId 12) "The [build failed ❌](example.com/alt/1b2)\n\
                                            \If this is the result of a flaky test, \
                                            \close and reopen the PR, then tag me again.\n\
                                            \Otherwise, push a new commit and tag me again."
@@ -2028,7 +2028,7 @@ main = hspec $ do
                         [PullRequestId 1]
                         False
         , ALeaveComment (PullRequestId 3) "Speculatively rebased as 3cd behind #1, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "The build failed: ci.example.com/1ab\n\
+        , ALeaveComment (PullRequestId 1) "The [build failed ❌](ci.example.com/1ab)\n\
                                           \If this is the result of a flaky test, \
                                           \close and reopen the PR, then tag me again.\n\
                                           \Otherwise, push a new commit and tag me again."
@@ -2660,7 +2660,7 @@ main = hspec $ do
           , BuildStatusChanged (Sha "36a") (Project.BuildSucceeded) -- arbitrary sha, ignored
           , BuildStatusChanged (Sha "2bc") (Project.BuildFailed (Just "example.com/2bc")) -- PR#8
           , BuildStatusChanged (Sha "2bc") (Project.BuildFailed (Just "example.com/2bc")) -- dup!
-          , CommentAdded (PullRequestId 8) "bot" "The build failed: example.com/2bc"
+          , CommentAdded (PullRequestId 8) "bot" "The [build failed ❌](example.com/2bc)"
           , CommentAdded (PullRequestId 7) "bot" "Rebased as 3cd, waiting for CI …"
           , BuildStatusChanged (Sha "3ef") (Project.BuildStarted "example.com/3ef")
           , BuildStatusChanged (Sha "3ef") (Project.BuildSucceeded) -- testing build passed on PR#7
@@ -2711,7 +2711,7 @@ main = hspec $ do
         , ACleanupTestBranch (PullRequestId 9)
         , ALeaveComment (PullRequestId 8) "[CI job 🟡](example.com/2bc) started."
         , ALeaveComment (PullRequestId 8)
-                        "The build failed: example.com/2bc\n\
+                        "The [build failed ❌](example.com/2bc)\n\
                         \If this is the result of a flaky test, \
                         \close and reopen the PR, then tag me again.\n\
                         \Otherwise, push a new commit and tag me again."


### PR DESCRIPTION
Closes #151

I ran into various issues trying to test this locally. For example, `stack` assumes `nix` is installed which wasn't listed as a requirement. (Note the _If using Nix_ in the README).
Either way, since this is a fairly trivial markdown change I thought I would still submit the PR.

Let me know if this requires any changes 😄 