### PR TITLE
Expose running version on CLI and Web

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -79,6 +79,9 @@ blocks:
             # Print working directory for debugging purposes
             - "pwd"
 
+            # Check version consistency between hoff.cabal and hoff.nix
+            - "./package/check-version.sh"
+
             # Run build and tests in Nix
             # Because this is a public repository, and not everyone is using Nix,
             # we keep the stack setup around. The Nix build however is used in production.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,7 @@ import Control.Monad (forM, unless, void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Logger (runStdoutLoggingT)
 import Data.List (zip4)
+import Data.Version (showVersion)
 import System.Exit (die)
 import System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
 
@@ -29,6 +30,8 @@ import Project (ProjectState, emptyProjectState, loadProjectState, saveProjectSt
 import Project (ProjectInfo (ProjectInfo), Owner)
 import Server (buildServer)
 
+import qualified Paths_hoff (version)
+
 import qualified Configuration as Config
 import qualified Git
 import qualified Github
@@ -36,6 +39,9 @@ import qualified GithubApi
 import qualified Logic
 import qualified Project
 import qualified Time
+
+version :: String
+version = showVersion Paths_hoff.version
 
 data Options = Options
   { configFilePath :: FilePath
@@ -46,8 +52,12 @@ commandLineParser :: Opts.ParserInfo Options
 commandLineParser =
   let
     optConfigFilePath = Opts.argument Opts.str (Opts.metavar "<config-file>")
-    optReadOnly = Opts.switch (Opts.long "read-only")
-    opts = Options <$> optConfigFilePath <*> optReadOnly
+    optReadOnly = Opts.switch $ Opts.long "read-only"
+                             <> Opts.help "Run in read-only mode"
+    optVersion = Opts.infoOption ("Hoff v" <> version)
+               $  Opts.long "version"
+               <> Opts.help "Displays version and exit"
+    opts = Options <$> optConfigFilePath <*> optReadOnly <* optVersion
     help = Opts.fullDesc <> Opts.header "A gatekeeper for your commits"
   in
     Opts.info (opts <**> Opts.helper) help
@@ -92,6 +102,7 @@ runMain options = do
   hSetBuffering stdout LineBuffering
   hSetBuffering stderr LineBuffering
 
+  putStrLn $ "Starting Hoff v" ++ version
   putStrLn $ "Config file: " ++ (configFilePath options)
   putStrLn $ "Read-only: " ++ (show $ readOnly options)
 

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,4 +1,5 @@
 name:                hoff
+-- please keep version consistent with hoff.nix
 version:             0.27.0
 category:            Development
 synopsis:            A gatekeeper for your commits
@@ -61,6 +62,8 @@ library
                , wai
                , warp
                , warp-tls
+  other-modules: Paths_hoff
+  autogen-modules: Paths_hoff
 
 executable hoff
   default-language: Haskell2010
@@ -76,6 +79,8 @@ executable hoff
                , monad-logger
                , optparse-applicative
                , text
+  other-modules: Paths_hoff
+  autogen-modules: Paths_hoff
 
 test-suite spec
   default-language: Haskell2010

--- a/hoff.nix
+++ b/hoff.nix
@@ -4,7 +4,7 @@ let
 in
   haskellPackages.mkDerivation {
     pname = "hoff";
-    version = "0.27.0";
+    version = "0.27.0"; # please keep consistent with hoff.cabal
 
     src =
       let

--- a/package/check-version.sh
+++ b/package/check-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Checks if the version number is consistent between hoff.cabal and hoff.nix
+cabal_version=$(
+	grep "^version:" <hoff.cabal |
+	sed 's/.*version: *//;  s/ .*//'
+)
+nix_version=$(
+	grep "^[\t ]*version *=" <hoff.nix |
+	sed 's/.*version *= *"//; s/".*//'
+)
+
+[ "$cabal_version" = "$nix_version" ] && exit 0
+
+cat <<MESSAGE
+mismatch in versions between hoff.cabal and hoff.nix:
+* hoff.cabal:     $cabal_version
+* hoff.nix:       $nix_version
+MESSAGE
+exit 1

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -18,12 +18,13 @@ import Data.ByteArray.Encoding (Base (Base64, Base64URLUnpadded), convertToBase)
 import Data.FileEmbed (embedStringFile)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Data.Version (showVersion)
 import Prelude hiding (div, head, id, span)
 import Text.Blaze (toValue, (!))
 import Text.Blaze.Html.Renderer.Utf8
 import Text.Blaze.Html5 (Html, a, body, div, docTypeHtml, h1, h2, h3, head, link, meta, p, span,
                          title, toHtml)
-import Text.Blaze.Html5.Attributes (charset, class_, content, href, id, name, rel)
+import Text.Blaze.Html5.Attributes (charset, class_, content, href, id, name, rel, style)
 import Text.Blaze.Internal (Attribute, AttributeValue, attribute)
 
 import qualified Data.ByteString.Lazy as LazyByteString
@@ -36,6 +37,8 @@ import Project (Approval (..), BuildStatus (..), IntegrationStatus (..), Owner, 
 import Types (PullRequestId (..), Username (..))
 
 import qualified Project
+
+import Paths_hoff (version)
 
 -- TODO: Minify this css at inclusion time.
 stylesheet :: Text
@@ -79,8 +82,9 @@ renderPage pageTitle bodyHtml = renderHtml $ docTypeHtml $ do
     link ! rel "stylesheet" ! href (toValue googlefontsUrl)
     link ! rel "stylesheet" ! href (toValue stylesheetUrl) ! integrity (toValue $ "sha256-" <> stylesheetBase64Digest)
   body $
-    div ! id "content" $
+    div ! id "content" $ do
       bodyHtml
+      p ! style "text-align:right;font-size:smaller;margin-top:2em" $ "Hoff v" <> toHtml (showVersion version)
 
 -- Integrity attribute for subresource integrity. Blaze doesn't have
 -- this yet, but this is what their implementation would look like.


### PR DESCRIPTION
Closes: #123

Expose the running version of Hoff in the CLI and Web.

This is useful for avoiding mistakes when deploying: the version number will clearly indicate which version is deployed at a given URL and in the logs.

See the updated CLI and web interfaces below:

```bash
$ nix run -c stack exec hoff -- --help
A gatekeeper for your commits

Usage: hoff <config-file> [--read-only] [--version]

Available options:
  --read-only              Run in read-only mode
  --version                Displays version and exit
  -h,--help                Show this help text
```

```bash
$ nix run -c stack exec hoff -- --version
Hoff v0.26.2
```

```bash
$ nix run -c stack exec hoff config.json --no-nix-pure
Starting Hoff v0.26.2
Config file: config.json
Read-only: False
Loaded project state from './run/state/git-sandbox.json'.
[Info] logic loop received event: Synchronize
...
```

On the web interface, the version is discreetly displayed at the bottom-right of all pages, see:

![version-on-web](https://user-images.githubusercontent.com/3999598/184886572-59e17a01-0418-4143-8a2c-5df8225b6b0c.png)

------

![repo](https://user-images.githubusercontent.com/3999598/184887196-39145b18-e9a5-4253-98b9-8b5f7d6f21ca.png)



### TODO

- [x] Add `Version` module exposing `version :: String`;
- [x] Add `--version` switch;
- [x] State version when starting Hoff;
- [x] Test that `Version.version` and `hoff.cabal:version:` are the same if possible
    - [x] ... and also that hoff.nix has the same version as well...
- [x] Document `--version` and `--read-only` switches (upon `--help`);
- [x] Display version on the web interface
- [x] Create sibling PR to update internal documentation with an extra deploy step (`src/Version.hs`) bump
- [x] ~Add `@hoffbot version` command?~ Not now.  I will do this in a separate PR.