### PR TITLE
skip `testing` branch preemptive deletion

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -166,11 +166,6 @@ runAction config = foldFree $ \case
   TryIntegrate message (pr, ref, sha) train alwaysAddMergeCommit cont -> do
     doGit $ ensureCloned config
 
-    -- Needed for backwards compatibility with existing repositories
-    -- as we now test at testing/<pr_id> instead of testing.
-    -- When no repositories have a testing branch, this can safely be removed.
-    _ <- doGit $ Git.deleteRemoteBranch $ Git.Branch $ Config.testBranch config
-
     let targetBranch = fromMaybe (Git.Branch $ Config.branch config) (trainBranch train)
 
     shaOrFailed <- doGit $ Git.tryIntegrate


### PR DESCRIPTION
closes: #165 

In #134, we transitioned from testing on `testing/<id>` instead of just
`testing`.  In order to maintain backwards compatibility, we had to delete
`testing` every time we created a new `testing/<id>` branch.

That has been a month ago, and most projects that use Hoff should have had at
least one PR triggering the deletion of `testing`.  So we should remove this
code that tries deletion every time.

We currently see the following in the logs every time we merge:

```haskell
Aug 18 13:37:12 hoff hoff[4321]: [Warn] error: git push -d failed. Reason: error: unable to delete 'testing': remote ref does not exist
Aug 18 13:37:29 hoff hoff[4321]: error: failed to push some refs to 'git@github.com:<org>/<repo>.git'
```

This should get rid of entries like the above.

<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->
