### PR TITLE
unintegrate the rest of the train on failed pushes

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -768,8 +768,10 @@ pushCandidate (pullRequestId, pullRequest) newHead state =
              $ Pr.setIntegrationStatus pullRequestId Promoted state
       -- If something was pushed to the target branch while the candidate was
       -- being tested, try to integrate again and hope that next time the push
-      -- succeeds.
-      PushRejected _why -> tryIntegratePullRequest pullRequestId state
+      -- succeeds.  We also cancel integrations in the merge train.
+      -- These should be automatically restarted when we 'proceed'.
+      PushRejected _why -> tryIntegratePullRequest pullRequestId
+                         $ unintegrateAfter pullRequestId state
 
 -- | When a pull request has been promoted to master this means that any
 -- conflicts (failed rebases) built on top of it are not speculative anymore:


### PR DESCRIPTION
Closes: #170 

When a promotion (push to master) fails, we should not only reintegrate the head PR, but also unintegrate the rest of the train so that it is reintegrated on top of the new head PR.

<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

Adding automated tests to this will not be easy, so I ended up testing manually.  There is no way to simlulate integration failures from the free monad interface.  See the 4 PRs that link here for a couple of local test runs:

![church](https://user-images.githubusercontent.com/3999598/186196870-0648fee9-b699-4519-b661-a79dd2f5b6b9.png)

:arrow_up: Here the speculative rebase was done immediately after we failed to promote the other PR due to its testing branch being stale.

------

![haskell](https://user-images.githubusercontent.com/3999598/186196877-1660e67e-8b3f-4f1f-b558-ee65c528505d.png)

