### PR TITLE
Upon PR closure, only reintegrate later pull requests if it is integrated

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -380,9 +380,10 @@ handlePullRequestClosed closingReason pr state = do
   -- actually delete the pull request
   pure . Pr.deletePullRequest pr
        $ case Pr.lookupPullRequest pr state of
-         Just (Pr.PullRequest{Pr.integrationStatus = Promoted}) -> state
-         -- we unintegrate PRs after it if it has not been promoted to master
-         _ -> unintegrateAfter pr $ state
+         -- we unintegrate PRs after if it has been integrated without promotion
+         -- as everything that was built on top of it needs to be rebuilt
+         Just (Pr.PullRequest{Pr.integrationStatus = Integrated _ _}) -> unintegrateAfter pr state
+         _ -> state
 
 handlePullRequestEdited :: PullRequestId -> Text -> BaseBranch -> ProjectState -> Action ProjectState
 handlePullRequestEdited prId newTitle newBaseBranch state =

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -2103,6 +2103,78 @@ main = hspec $ do
                         \ do not belong to any other commits."
         ]
 
+    it "new commits on conflicted PRs should not reset other PRs in the train\
+       \(success, wrongfixups (success), success)" $ do
+      let
+        state
+          = Project.insertPullRequest (PullRequestId 1) (Branch "fst") masterBranch (Sha "ab1") "First PR"  (Username "tyrell")
+          $ Project.insertPullRequest (PullRequestId 2) (Branch "snd") masterBranch (Sha "cd2") "Second PR" (Username "rachael")
+          $ Project.insertPullRequest (PullRequestId 3) (Branch "trd") masterBranch (Sha "ef3") "Third PR"  (Username "tyrell")
+          $ Project.emptyProjectState
+        events =
+          [ CommentAdded (PullRequestId 1) "deckard" "@bot merge"
+          , CommentAdded (PullRequestId 2) "deckard" "@bot merge"
+          , CommentAdded (PullRequestId 3) "deckard" "@bot merge"
+          , PullRequestCommitChanged (PullRequestId 2) (Sha "c2d")
+          , CommentAdded (PullRequestId 2) "deckard" "@bot merge"
+          ]
+        results = defaultResults { resultIntegrate = [ Right (Sha "1ab")
+                                                     , Left (IntegrationFailure (BaseBranch "testing/1") WrongFixups)
+                                                     , Right (Sha "3cd")
+                                                     , Right (Sha "2bc") ] }
+        run = runActionCustom results
+        actions = snd $ run $ handleEventsTest events state
+      actions `shouldBe`
+        [ AIsReviewer "deckard"
+        , ALeaveComment (PullRequestId 1)
+                        "Pull request approved for merge by @deckard, rebasing now."
+        , ATryIntegrate "Merge #1: First PR\n\n\
+                        \Approved-by: deckard\n\
+                        \Auto-deploy: false\n"
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
+                        []
+                        False
+        , ALeaveComment (PullRequestId 1) "Rebased as 1ab, waiting for CI …"
+        , AIsReviewer "deckard"
+        , ALeaveComment (PullRequestId 2)
+                       "Pull request approved for merge by @deckard, \
+                       \waiting for rebase behind one pull request."
+        , ATryIntegrate "Merge #2: Second PR\n\n\
+                        \Approved-by: deckard\n\
+                        \Auto-deploy: false\n"
+                        (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
+                        [PullRequestId 1]
+                        False
+        , ALeaveComment (PullRequestId 2)
+                        "Pull request cannot be integrated\
+                        \ as it contains fixup commits that\
+                        \ do not belong to any other commits."
+        , AIsReviewer "deckard"
+        , ALeaveComment (PullRequestId 3)
+                       "Pull request approved for merge by @deckard, \
+                       \waiting for rebase behind one pull request."
+        , ATryIntegrate "Merge #3: Third PR\n\n\
+                        \Approved-by: deckard\n\
+                        \Auto-deploy: false\n"
+                        (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
+                        [PullRequestId 1]
+                        False
+        , ALeaveComment (PullRequestId 3) "Speculatively rebased as 3cd behind #1, waiting for CI …"
+        -- upon commit changed on PR#2, there is no reason to reintegrate PR#3
+        -- PR#2 is moved to the end of the train after a new merge command
+        , AIsReviewer "deckard"
+        , ALeaveComment (PullRequestId 2)
+                       "Pull request approved for merge by @deckard, \
+                       \waiting for rebase behind 2 pull requests."
+        , ATryIntegrate "Merge #2: Second PR\n\n\
+                        \Approved-by: deckard\n\
+                        \Auto-deploy: false\n"
+                        (PullRequestId 2, Branch "refs/pull/2/head", Sha "c2d")
+                        [PullRequestId 1, PullRequestId 3]
+                        False
+        , ALeaveComment (PullRequestId 2) "Speculatively rebased as 2bc behind #1 and #3, waiting for CI …"
+        ]
+
     it "handles a 2-wagon merge train with build successes coming in the right order: success (1), success (2)" $ do
       let
         state


### PR DESCRIPTION
Closes: #161 

Upon PR closure, only reintegrate later pull requests if it is integrated.

1. A new test was added to assure that this case was caught.  The [build fails :x:](https://channable.semaphoreci.com/jobs/0ff6a996-9e1e-4739-a6fa-ed067ed31914#L766-L777) on the first commit as proof of this;
2. The behaviour of `handlePullRequestClosed` was fixed.  The [build passes :heavy_check_mark:](https://channable.semaphoreci.com/workflows/e8fce27f-0ab9-40e7-acec-f0936d37249e?pipeline_id=cf23c90c-7d3d-4d2b-99e7-f0552d5c6809) on the second commit.

Before an early PR closure (or new commit) had the power to unintegrate PRs in the train, regardless if this PR was integrated or not!  The unintegration of later PRs should only happen when the PR being closed has been integrated and thus is the base for these following PRs.
