### PR TITLE
Ignore build status changes on just the URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,39 +130,6 @@ with systemd. TODO: Make it work with portablectl.
 You can also build Hoff as a deb package by running:
 `./package/build-and-ship.sh`
 
-## Known issues
-
-### Multiple CI job started comments (#147)
-
-Hoff reports all build links for builds that could trigger success/failure.
-So sometimes Hoff may comment:
-
-> [CI job](https://ci.example.com/link1111) started.
-
-(30 seconds later)
-
-> [CI job](https://ci.example.com/link2222) started.
-
-If you look closely, you will see that the subsequent links are different.
-
-This only happens when there are two branches pointing to the same commit hash
-that are building at the same time.  Multiple CI jobs are created and we are
-notified of changes in all.
-
-In a regular Hoff workflow, this may happen if the following conditions are
-met: a PR contains a single commit; it can be fastforwarded on top of master;
-and the `@hoffbot merge` comment happens early enough so that builds are
-parallel.  This should happen infrequently enough for it not to be a nuisance.
-
-When the PR has multiple commits, this should not happen as Hoff will create a
-unique merge commit.  Unless of course one manually duplicates the Hoff testing
-branch.
-
-Unfortunately the [GitHub webhook for the build status] provides no way to
-check the canonical branch for the build link (#147, #148, [faf04c9]).  We are
-left with a choice of reporting only the first link or all links that arrive.
-We chose the latter as success ✅ or failure ❌ depends the result of the first
-of the builds to complete.
 
 ## Further reading
 

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -597,13 +597,22 @@ handleBuildStatusChanged buildSha newStatus state = pure $
 -- * Statuses 'BuildSuceeded' and 'BuildFailed' are not
 --   superseded by other statuses
 --
+-- * We ignore changes of just the URL.
+--
 -- This is used in 'handleBuildStatusChanged`.
 supersedes :: BuildStatus -> BuildStatus -> Bool
-newStatus       `supersedes` oldStatus       | newStatus == oldStatus = False
-(BuildFailed _) `supersedes` (BuildFailed _) = True
-_               `supersedes` (BuildFailed _) = False
-_               `supersedes` BuildSucceeded  = False
-_               `supersedes` _               = True
+newStatus `supersedes` oldStatus        | sameStatus newStatus oldStatus
+                                        = False -- url change, ignore
+_         `supersedes` (BuildFailed _)  = False -- final status
+_         `supersedes` BuildSucceeded   = False -- final status
+_         `supersedes` _                = True
+
+-- | Compares if two build statuses are the same
+--   while ignoring any URL arguments
+sameStatus :: BuildStatus -> BuildStatus -> Bool
+sameStatus BuildStarted{} BuildStarted{} = True
+sameStatus BuildFailed{}  BuildFailed{}  = True
+sameStatus status1        status2        = status1 == status2
 
 -- Query the GitHub API to resolve inconsistencies between our state and GitHub.
 synchronizeState :: ProjectState -> Action ProjectState

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1819,6 +1819,35 @@ main = hspec $ do
       state `shouldBe` state'
       removeFile fname
 
+    it "ignore build status changes where only the URL is changed" $ do
+      let
+        state
+          = Project.insertPullRequest (PullRequestId 12)
+              (Branch "tth") masterBranch (Sha "12a") "Twelfth PR"  (Username "person")
+          $ Project.emptyProjectState
+        results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
+        events =
+          [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
+          , CommentAdded (PullRequestId 12) "bot" "Pull request approved for merge, rebasing now."
+          , CommentAdded (PullRequestId 12) "bot" "Rebased as 1b2, waiting for CI …"
+          , BuildStatusChanged (Sha "1b2") (Project.BuildStarted "example.com/1b2")
+          , BuildStatusChanged (Sha "1b2") (Project.BuildStarted "example.com/alt1/1b2")
+          , BuildStatusChanged (Sha "1b2") (Project.BuildStarted "example.com/alt2/1b2")
+          ]
+        actions = snd $ runActionCustom results $ handleEventsTest events state
+      actions `shouldBe`
+        [ AIsReviewer (Username "deckard")
+        , ALeaveComment (PullRequestId 12) "Pull request approved for merge by @deckard, rebasing now."
+        , ATryIntegrate "Merge #12: Twelfth PR\n\n\
+                        \Approved-by: deckard\n\
+                        \Auto-deploy: false\n"
+                        (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
+                        []
+                        False
+        , ALeaveComment (PullRequestId 12) "Rebased as 1b2, waiting for CI …"
+        , ALeaveComment (PullRequestId 12) "[CI job :yellow_circle:](example.com/1b2) started."
+        ]
+
     it "build failures cannot be superseded by other statuses" $ do
       let
         state
@@ -1835,7 +1864,7 @@ main = hspec $ do
           , BuildStatusChanged (Sha "1b2") (Project.BuildFailed (Just "example.com/1b2"))
           , BuildStatusChanged (Sha "1b2") Project.BuildPending -- ignored
           , BuildStatusChanged (Sha "1b2") (Project.BuildStarted "example.com/1b2") -- ignored
-          , BuildStatusChanged (Sha "1b2") (Project.BuildFailed (Just "example.com/alt/1b2"))
+          , BuildStatusChanged (Sha "1b2") (Project.BuildFailed (Just "example.com/alt/1b2")) --ignored
           , BuildStatusChanged (Sha "1b2") Project.BuildSucceeded -- ignored
           ]
         actions = snd $ runActionCustom results $ handleEventsTest events state
@@ -1851,10 +1880,6 @@ main = hspec $ do
         , ALeaveComment (PullRequestId 12) "Rebased as 1b2, waiting for CI …"
         , ALeaveComment (PullRequestId 12) "[CI job :yellow_circle:](example.com/1b2) started."
         , ALeaveComment (PullRequestId 12) "The [build failed :x:](example.com/1b2).\n\n\
-                                           \If this is the result of a flaky test, \
-                                           \close and reopen the PR, then tag me again.  \
-                                           \Otherwise, push a new commit and tag me again."
-        , ALeaveComment (PullRequestId 12) "The [build failed :x:](example.com/alt/1b2).\n\n\
                                            \If this is the result of a flaky test, \
                                            \close and reopen the PR, then tag me again.  \
                                            \Otherwise, push a new commit and tag me again."


### PR DESCRIPTION
Fixes: #147 

This PR makes Hoff ignore build status change where the only change is in the URL.  This make it so that "CI job started" messages are not duplicated anymore (or triplicated (or quadruplicated (or quintuplicated (or ...)))).