### PR TITLE
log repository name

### DIFF
--- a/src/GithubApi.hs
+++ b/src/GithubApi.hs
@@ -115,7 +115,8 @@ runGithub auth projectInfo operation =
         body
       case result of
         Left err -> logWarnN $ format "Failed to comment: {}" [show err]
-        Right _ -> logInfoN $ format "Posted comment on {}: {}" (pr, body)
+        Right _ -> logInfoN $ format "Posted comment on {}#{}: {}"
+                                     (Project.repository projectInfo, pr, body)
       pure cont
 
     HasPushAccess (Username username) cont -> do


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

This updates some logging to include the relevant repository name.

"Posted comment on 182" now becomes "Posted comment on hoff#182".

# Logs after the change

```haskell
Starting Hoff v0.27.2
Config file: config.json
Read-only: False
Loaded project state from './run/state/git-sandbox.json'.
[Info] logic loop received event (git-sandbox): Synchronize
[Debug] state before (git-sandbox): ProjectState ...
[Debug] Getting open pull request in .../git-sandbox.
Listening for webhooks on port 1979.
[Debug] Got 6 open pull requests in .../git-sandbox.
[Debug] state after (git-sandbox): ProjectState ...
[Debug] github loop received event: Comment (CommentPayload {action = Left CommentCreated, owner = "...", repository = "git-sandbox", number = 144, author = Username "rudymatela", body = "This is a comment."})
[Info] logic loop received event (git-sandbox): CommentAdded (PullRequestId 144) (Username "rudymatela") "This is a comment."
[Debug] state before (git-sandbox): ProjectState ...
[Debug] state after (git-sandbox): ProjectState ...
...
[Info] Posted comment on git-sandbox#12345: Pull request approved for merge and deploy by @rudymatela, waiting for rebase behind one pull request.
[Info] Posted comment on git-sandbox#12345: Speculatively rebased as 0123456789abcdef behind #12346, waiting for CI …
```

Above :arrow_up:, we know exactly to which repository each log entry belongs to.

# Logs before the change

```haskell
Starting Hoff v0.27.2
Config file: config.json
Read-only: False
Loaded project state from './run/state/git-sandbox.json'.
[Info] logic loop received event: Synchronize
[Debug] state before: ProjectState ...
[Debug] Getting open pull request in .../git-sandbox.
Listening for webhooks on port 1979.
[Debug] Got 6 open pull requests in .../git-sandbox.
[Debug] state after: ProjectState ...
[Debug] github loop received event: Comment (CommentPayload {action = Left CommentCreated, owner = "...", repository = "git-sandbox", number = 144, author = Username "rudymatela", body = "This is a comment."})
[Info] logic loop received event: CommentAdded (PullRequestId 144) (Username "rudymatela") "This is a comment."
[Debug] state before: ProjectState ...
[Debug] state after: ProjectState ...
...
[Info] Posted comment on 12345: Pull request approved for merge and deploy by @rudymatela, waiting for rebase behind one pull request.
[Info] Posted comment on 12345: Speculatively rebased as 0123456789abcdef behind #12346, waiting for CI …
```

Above :arrow_up:, if we are tracking multiple projects/repositories in the log, we have no way to know which log entry belongs to which repo.