### PR TITLE
CI: move to Ubuntu 20.04

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,7 +5,7 @@ name: "Hoff"
 agent:
   machine:
     type: "e1-standard-4"
-    os_image: "ubuntu1804"
+    os_image: "ubuntu2004"
 
 # If we push a new build to some branch that isn't master, and another build is
 # already running, we cancel it.
@@ -40,12 +40,15 @@ blocks:
             - "cache restore stack-cache-"
 
             # Install Nix and source the shell configuration immediately.
-            - "./nix/install"
+            - "./nix/install --no-daemon"
             - ". $HOME/.nix-profile/etc/profile.d/nix.sh"
 
             # Install Cachix and use the Channable cache
             - "nix-env -iA nixpkgs.cachix"
             - "cachix use channable-public"
+
+            # Build as many derivations as cores in parallel.
+            - echo "max-jobs = auto" >> ~/.config/nix/nix.conf
 
             # Bring all the tools from the pinned build environment into the PATH.
             - "export PATH=$(nix-build --no-out-link default.nix)/bin:$PATH"


### PR DESCRIPTION
This PR updates the CI pipeline to use Ubuntu 20.04. In addition, it configures Nix to use all cores to build derivations.