### PR TITLE
Add Prometheus-readable metrics endpoint

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@ in
       pkgs.dpkg
       pkgs.git
       pkgs.haskellPackages.haskell-language-server
+      pkgs.haskellPackages.stylish-haskell
       pkgs.niv
       pkgs.shellcheck
       pkgs.stack

--- a/doc/example-dev-config.json
+++ b/doc/example-dev-config.json
@@ -19,5 +19,9 @@
   "mergeWindowExemption": ["hoffbot"],
   "trigger": {
     "commentPrefix": "@hoffbot"
+  },
+  "metrics": {
+    "metricsPort": 3333,
+    "metricsHost": "*"
   }
 }

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -28,6 +28,8 @@ library
                  , Logic
                  , Project
                  , Server
+                 , Metrics.Server
+                 , Metrics.Metrics
                  , Time
                  , Types
                  , WebInterface
@@ -53,6 +55,8 @@ library
                , monad-logger
                , process
                , process-extras
+               , prometheus-client
+               , prometheus-metrics-ghc
                , scotty
                , stm
                , text
@@ -60,6 +64,7 @@ library
                , time
                , vector
                , wai
+               , wai-middleware-prometheus
                , warp
                , warp-tls
   other-modules: Paths_hoff

--- a/nix/haskell-dependencies.nix
+++ b/nix/haskell-dependencies.nix
@@ -29,6 +29,8 @@ haskellPackages: with haskellPackages; [
   optparse-applicative
   process
   process-extras
+  prometheus
+  prometheus-metrics-ghc
   scotty
   stm
   text
@@ -37,6 +39,7 @@ haskellPackages: with haskellPackages; [
   uuid
   vector
   wai
+  wai-middleware-prometheus
   warp
   warp-tls
 ]

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -15,6 +15,7 @@ module Configuration
   TriggerConfiguration (..),
   UserConfiguration (..),
   MergeWindowExemptionConfiguration (..),
+  MetricsConfiguration (..),
   loadConfiguration
 )
 where
@@ -24,6 +25,7 @@ import Data.ByteString (readFile)
 import Data.Text (Text)
 import GHC.Generics
 import Prelude hiding (readFile)
+import qualified Network.Wai.Handler.Warp as Warp
 
 data ProjectConfiguration = ProjectConfiguration
   {
@@ -62,6 +64,13 @@ data TlsConfiguration = TlsConfiguration
   }
   deriving (Generic, Show)
 
+data MetricsConfiguration = MetricsConfiguration
+  {
+    metricsPort :: Warp.Port,
+    metricsHost :: Text
+  }
+  deriving (Generic, Show)
+
 newtype MergeWindowExemptionConfiguration = MergeWindowExemptionConfiguration [Text]
   deriving (Generic, Show)
 
@@ -95,7 +104,10 @@ data Configuration = Configuration
 
     -- List of users that are exempted from the merge window. This is useful for
     -- bots that automatically merge low impact changes.
-    mergeWindowExemption :: MergeWindowExemptionConfiguration
+    mergeWindowExemption :: MergeWindowExemptionConfiguration,
+
+    -- Configuration for the Prometheus metrics server.
+    metricsConfig :: Maybe MetricsConfiguration
   }
   deriving (Generic)
 
@@ -105,6 +117,7 @@ instance FromJSON TlsConfiguration
 instance FromJSON TriggerConfiguration
 instance FromJSON UserConfiguration
 instance FromJSON MergeWindowExemptionConfiguration
+instance FromJSON MetricsConfiguration
 
 -- Reads and parses the configuration. Returns Nothing if parsing failed, but
 -- crashes if the file could not be read.

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -26,6 +26,7 @@ import Control.Monad.STM (atomically)
 import Control.Monad.Free (foldFree)
 import Data.Foldable (traverse_)
 import Data.Functor.Sum (Sum (InL, InR))
+import Prometheus (MonadMonitor)
 
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -42,6 +43,7 @@ import qualified Github
 import qualified GithubApi
 import qualified Logic
 import qualified Project
+import qualified Metrics.Metrics as Metrics
 
 eventFromPullRequestPayload :: PullRequestPayload -> Logic.Event
 eventFromPullRequestPayload payload =
@@ -128,10 +130,12 @@ runSum runF runG = go
 runLogicEventLoop
   :: MonadIO m
   => MonadLogger m
+  => MonadMonitor m
   => TriggerConfiguration
   -> ProjectConfiguration
   -> MergeWindowExemptionConfiguration
   -- Interpreters for Git and GitHub actions.
+  -> (forall a. Metrics.MetricsOperationFree a -> m a)
   -> (forall a. Time.TimeOperationFree a -> m a)
   -> (forall a. Git.GitOperationFree a -> m a)
   -> (forall a. GithubApi.GithubOperationFree a -> m a)
@@ -145,10 +149,10 @@ runLogicEventLoop
   -> m ProjectState
 runLogicEventLoop
   triggerConfig projectConfig mergeWindowExemptionConfig
-  runTime runGit runGithub
+  runMetrics runTime runGit runGithub
   getNextEvent publish initialState =
   let
-    runAll      = foldFree (runSum runTime (runSum runGit runGithub))
+    runAll      = foldFree (runSum (runSum runMetrics runTime) (runSum runGit runGithub))
     runAction   = Logic.runAction projectConfig
 
     handleAndContinue state0 event = do

--- a/src/Metrics/Metrics.hs
+++ b/src/Metrics/Metrics.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Metrics.Metrics
+(
+  MetricsOperation,
+  MetricsOperationFree (..),
+  ProjectMetrics (..),
+  runMetrics,
+  runLoggingMonitorT,
+  runNoMonitorT,
+  increaseMergedPRTotal,
+  registerGHCMetrics,
+  registerProjectMetrics
+  )
+where
+
+import Data.Text
+import Prometheus
+import Prometheus.Metric.GHC (ghcMetrics)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.Free (Free)
+import Control.Monad.Logger (LoggingT, MonadLogger, NoLoggingT)
+import Control.Monad.Free.Ap (liftF)
+import Control.Monad (void)
+
+type ProjectLabel = Text
+
+data ProjectMetrics = ProjectMetrics
+  { projectMetricsMergedPR :: Vector ProjectLabel Counter
+  }
+
+data MetricsOperationFree a
+  = MergeBranch a
+  deriving (Functor)
+
+type MetricsOperation = Free MetricsOperationFree
+
+newtype LoggingMonitorT m a = LoggingMonitorT { runLoggingMonitorT :: LoggingT m a }
+                              deriving (Functor, Applicative, Monad, MonadIO, MonadLogger)
+
+newtype NoMonitorT m a = NoMonitorT { runNoMonitorT :: NoLoggingT m a }
+                       deriving (Functor, Applicative, Monad, MonadIO, MonadLogger)
+
+instance MonadIO m => MonadMonitor (LoggingMonitorT m) where
+  doIO = liftIO
+
+
+instance MonadIO m => MonadMonitor (NoMonitorT m) where
+  doIO _ = return ()
+
+increaseMergedPRTotal :: MetricsOperation ()
+increaseMergedPRTotal = liftF $ MergeBranch ()
+
+runMetrics
+  :: (MonadMonitor m, MonadIO m)
+  => ProjectMetrics
+  -> ProjectLabel
+  -> MetricsOperationFree a
+  -> m a
+runMetrics metrics label operation =
+  case operation of
+    MergeBranch cont -> cont <$
+      incProjectMergedPR metrics label
+
+registerGHCMetrics :: IO ()
+registerGHCMetrics = void $ register ghcMetrics
+
+registerProjectMetrics :: IO ProjectMetrics
+registerProjectMetrics = ProjectMetrics
+  <$> register (vector "project" (counter (Info "hoff_project_merged_pull_requests"
+                                                 "Number of merged pull requests")))
+
+incProjectMergedPR :: (MonadMonitor m, MonadIO m) => ProjectMetrics -> ProjectLabel -> m ()
+incProjectMergedPR metrics project =
+  withLabel (projectMetricsMergedPR metrics) project incCounter

--- a/src/Metrics/Server.hs
+++ b/src/Metrics/Server.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Metrics.Server
+(
+  MetricsServerConfig (..),
+  serverConfig,
+  runMetricsServer
+)
+where
+
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.Wai.Middleware.Prometheus as PrometheusWai
+import Data.Function ((&))
+
+data MetricsServerConfig = MetricsServerConfig
+  { metricsConfigHost :: Warp.HostPreference
+  , metricsConfigPort :: Warp.Port
+  }
+
+serverConfig :: MetricsServerConfig -> Warp.Settings
+serverConfig config = Warp.defaultSettings
+  & Warp.setHost (metricsConfigHost config)
+  & Warp.setPort (metricsConfigPort config)
+
+runMetricsServer :: MetricsServerConfig -> IO ()
+runMetricsServer config = Warp.runSettings (serverConfig config) PrometheusWai.metricsApp

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -5,7 +5,7 @@ let
     mkDependencies = import ./nix/haskell-dependencies.nix;
 in
     nixpkgs.haskell.lib.buildStackProject {
-        name = "sharkmachine";
+        name = "hoff";
         # Not the GHC given by stack!
         ghc = nixpkgs.haskellPackages.ghcWithHoogle mkDependencies;
         buildInputs = with nixpkgs; [

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -232,6 +232,7 @@ runActionRws =
       GetLatestVersion _ cont -> cont <$> takeResultGetLatestVersion
       GetChangelog _ _ cont -> cont <$> takeResultGetChangelog
       GetDateTime cont -> cont <$> takeResultGetDateTime
+      IncreaseMergeMetric cont -> pure cont
 
 -- Simulates running the action. Use the provided results as result for various
 -- operations. Results are consumed one by one.


### PR DESCRIPTION
Fixes part of https://github.com/channable/hoff/issues/99 by showing Prometheus-readable metrics on a configurable port, only showing one metric (number of PRs merged) at the moment. Other metrics will be easier to add now, but they should be described in new issues, in more specific detail, when the need arises.