### PR TITLE
Add option to specify mandatory checks per project

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -21,14 +21,15 @@ import System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
 
 import qualified Control.Concurrent.Async as Async
 import qualified Data.Text.Encoding as Text
+import qualified Data.Map.Strict as Map
 import qualified GitHub.Auth as Github3
 import qualified System.Directory as FileSystem
 import qualified Options.Applicative as Opts
 
 import Configuration (Configuration, MetricsConfiguration (metricsPort, metricsHost))
 import EventLoop (runGithubEventLoop, runLogicEventLoop)
-import Project (ProjectState, emptyProjectState, loadProjectState, saveProjectState)
-import Project (ProjectInfo (ProjectInfo), Owner)
+import Project (ProjectInfo (ProjectInfo), Owner, ProjectState, emptyProjectState,
+                loadProjectState, saveProjectState, subMapByOwner)
 import Server (buildServer)
 
 import qualified Metrics.Metrics as Metrics
@@ -45,6 +46,7 @@ import qualified Logic
 import qualified Project
 import qualified Time
 import qualified Data.Text as Text
+import qualified Data.Set as Set
 
 version :: String
 version = showVersion Paths_hoff.version
@@ -78,22 +80,26 @@ loadConfigOrExit fname = do
     Right config -> return config
     Left msg -> die $ "Failed to parse configuration file '" ++ fname ++ "'.\n" ++ msg
 
-initializeProjectState :: FilePath -> IO ProjectState
-initializeProjectState fname = do
+-- | Initialize an empty project state.
+-- Note that the mandatory checks for a project are always fetched from the
+-- configuration file.
+initializeProjectState :: Project.MandatoryChecks -> FilePath -> IO ProjectState
+initializeProjectState mandatory fname = do
   exists <- FileSystem.doesFileExist fname
+  let setMandatoryChecks state = state { Project.mandatoryChecks = mandatory }
   if exists then do
     eitherState <- loadProjectState fname
     case eitherState of
       Right projectState -> do
         putStrLn $ "Loaded project state from '" ++ fname ++ "'."
-        return projectState
+        return (setMandatoryChecks projectState)
       Left msg -> do
         -- Fail loudly if something is wrong, and abort the program.
         die $ "Failed to parse project state in '" ++ fname ++ "' with error " ++ msg ++ ".\n" ++
               "Please repair or remove the file."
   else do
     putStrLn $ "File '" ++ fname ++ "' not found, starting with an empty state."
-    return emptyProjectState
+    return (setMandatoryChecks emptyProjectState)
 
 main :: IO ()
 main = Opts.execParser commandLineParser >>= runMain
@@ -129,46 +135,45 @@ runMain options = do
   -- Git operation), so the queue is expected to be empty most of the time.
   ghQueue <- Github.newEventQueue 10
 
-  -- Events do not stay in the webhook queue for long: they are converted into
-  -- logic events and put in the project queues, where the main event loop will
-  -- process them. This conversion process does not reject events, but it blocks
-  -- if the project queue is full (which will cause the webhook queue to fill
-  -- up, so the server will reject new events).
-  projectQueues <- forM (Config.projects config) $ \ pconfig -> do
+  -- Each project is treated in isolation, containing their own queue and state.
+  let mandatoryChecksFromConfig projectConfig = Project.MandatoryChecks
+        $ Set.mapMonotonic Project.Check
+        $ maybe mempty Config.mandatory
+        $ Config.checks projectConfig
+  projectThreadState <- Map.fromList <$> forM (Config.projects config) (\pconfig -> do
+    -- Events do not stay in the webhook queue for long: they are converted into
+    -- logic events and put in the project queues, where the main event loop will
+    -- process them. This conversion process does not reject events, but it blocks
+    -- if the project queue is full (which will cause the webhook queue to fill
+    -- up, so the server will reject new events).
     projectQueue <- Logic.newEventQueue 10
-    return (getProjectInfo pconfig, projectQueue)
+
+    -- Restore the previous state from disk if possible, or start clean.
+    projectState <- initializeProjectState
+      (mandatoryChecksFromConfig pconfig)
+      (Config.stateFile pconfig)
+
+    -- Keep track of the most recent state for every project, so the webinterface
+    -- can use it to serve a status page.
+    stateVar <- Logic.newStateVar projectState
+    let initializationState = ProjectThreadData pconfig projectQueue stateVar
+    return (getProjectInfo pconfig, initializationState))
 
   -- Define a function that enqueues an event in the right project queue.
   let
-    enqueueEvent projectInfo event =
+    enqueueEvent projectInfo event = do
       -- Call the corresponding enqueue function if the project exists,
       -- otherwise drop the event on the floor.
-      maybe (return ()) (\ queue -> Logic.enqueueEvent queue event) $
-      -- TODO: This is doing a linear scan over a linked list to find the right
-      -- queue. That can be improved. A lot.
-      lookup projectInfo projectQueues
+      maybe (return ()) (\ threadState -> Logic.enqueueEvent (projectThreadQueue threadState) event) $
+        Map.lookup projectInfo projectThreadState
 
   -- Start a worker thread to put the GitHub webhook events in the right queue.
   ghThread <- Async.async $ runStdoutLoggingT $ runGithubEventLoop ghQueue enqueueEvent
 
-  -- Restore the previous state from disk if possible, or start clean.
-  projectStates <- forM (Config.projects config) $ \ pconfig -> do
-    projectState <- initializeProjectState (Config.stateFile pconfig)
-    return (getProjectInfo pconfig, projectState)
-
-  -- Keep track of the most recent state for every project, so the webinterface
-  -- can use it to serve a status page.
-  stateVars <- forM projectStates $ \ (projectInfo, projectState) -> do
-    stateVar <- Logic.newStateVar projectState
-    return (projectInfo, stateVar)
-
   -- Start a main event loop for every project.
-  let
-    zipped = zip3 (Config.projects config) projectQueues stateVars
-    projectsThreadData = map (\(cfg, (_, a), (_, b)) -> ProjectThreadData cfg a b) zipped
   metrics <- Metrics.registerProjectMetrics
   Metrics.registerGHCMetrics
-  projectThreads <- forM projectsThreadData $ projectThread config options metrics
+  projectThreads <- forM (map snd (Map.toList projectThreadState)) $ projectThread config options metrics
 
   let
     -- When the webhook server receives an event, enqueue it on the webhook
@@ -176,11 +181,11 @@ runMain options = do
     ghTryEnqueue = Github.tryEnqueueEvent ghQueue
 
     -- Allow the webinterface to retrieve the latest project state per project.
-    getProjectState projectInfo = Logic.readStateVar <$> lookup projectInfo stateVars
+    readProjectState = Logic.readStateVar . projectThreadStateVar
+    getProjectState projectInfo = readProjectState <$> Map.lookup projectInfo projectThreadState
     getOwnerState :: Owner -> IO [(ProjectInfo, ProjectState)]
-    getOwnerState owner = do
-      let states = filter (\(projectInfo, _) -> Project.owner projectInfo == owner) stateVars
-      mapM (\(info, state) -> Logic.readStateVar state >>= \sVar -> pure (info, sVar)) states
+    getOwnerState owner =
+      Map.toList <$> mapM readProjectState (subMapByOwner owner projectThreadState)
 
   let
     port      = Config.port config

--- a/doc/example-dev-config.json
+++ b/doc/example-dev-config.json
@@ -5,7 +5,10 @@
     "branch": "master",
     "testBranch": "testing",
     "checkout": "./run/checkouts/git-sandbox",
-    "stateFile": "./run/state/git-sandbox.json"
+    "stateFile": "./run/state/git-sandbox.json",
+    "checks": {
+      "mandatory": []
+    }
   }],
   "secret": "REPLACE with output of 'head --bytes 32 /dev/urandom | base64'",
   "accessToken": "REPLACE with a new personal access token from https://github.com/settings/tokens",

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -79,6 +79,7 @@ executable hoff
 
   build-depends: async
                , base
+               , containers
                , directory
                , github
                , hoff
@@ -92,6 +93,7 @@ test-suite spec
   default-language: Haskell2010
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
+  other-modules:  ProjectSpec
   hs-source-dirs: tests
   ghc-options:    -Wall -Werror
 
@@ -104,9 +106,12 @@ test-suite spec
                , directory
                , filepath
                , free
+               , generic-arbitrary
                , hoff
                , hspec
                , hspec-core
+               , QuickCheck
+               , quickcheck-instances
                , text
                , time
                , transformers

--- a/nix/haskell-dependencies.nix
+++ b/nix/haskell-dependencies.nix
@@ -18,6 +18,7 @@ haskellPackages: with haskellPackages; [
   file-embed
   filepath
   free
+  generic-arbitrary
   github
   hspec
   hspec-core
@@ -31,6 +32,8 @@ haskellPackages: with haskellPackages; [
   process-extras
   prometheus
   prometheus-metrics-ghc
+  QuickCheck
+  quickcheck-instances
   scotty
   stm
   text

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -5,7 +5,10 @@
     "branch": "master",
     "testBranch": "testing",
     "checkout": "/var/lib/hoff/checkouts/your-username/your-repo",
-    "stateFile": "/var/lib/hoff/state/your-username/your-repo.json"
+    "stateFile": "/var/lib/hoff/state/your-username/your-repo.json",
+    "checks": {
+      "mandatory": []
+    }
   }],
   "secret": "run 'head --bytes 32 /dev/urandom | base64' and paste output here",
   "accessToken": "paste a personal access token for a bot user here",

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -20,13 +20,17 @@ where
 
 import Control.Concurrent.STM.TBQueue
 import Control.Monad (when)
+import Control.Monad.Free (foldFree)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Logger (MonadLogger, logDebugN, logInfoN)
 import Control.Monad.STM (atomically)
-import Control.Monad.Free (foldFree)
+import Data.Aeson (encode)
+import Data.ByteString.Lazy (toStrict)
+import Data.Either (fromRight)
 import Data.Foldable (traverse_)
-import Prometheus (MonadMonitor)
 import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8')
+import Prometheus (MonadMonitor)
 import qualified Data.Text as Text
 
 import Configuration (ProjectConfiguration, TriggerConfiguration, MergeWindowExemptionConfiguration)
@@ -87,10 +91,11 @@ mapCommitStatus status murl = case status of
 
 eventFromCommitStatusPayload :: CommitStatusPayload -> Logic.Event
 eventFromCommitStatusPayload payload =
-  let sha    = Github.sha    (payload :: CommitStatusPayload)
-      status = Github.status (payload :: CommitStatusPayload)
-      url    = Github.url    (payload :: CommitStatusPayload)
-  in  Logic.BuildStatusChanged sha (mapCommitStatus status url)
+  let sha     = Github.sha     (payload :: CommitStatusPayload)
+      status  = Github.status  (payload :: CommitStatusPayload)
+      url     = Github.url     (payload :: CommitStatusPayload)
+      context = Github.context (payload :: CommitStatusPayload)
+  in  Logic.BuildStatusChanged sha context (mapCommitStatus status url)
 
 convertGithubEvent :: Github.WebhookEvent -> Maybe Logic.Event
 convertGithubEvent event = case event of
@@ -141,19 +146,20 @@ runLogicEventLoop
   runMetrics runTime runGit runGithub
   getNextEvent publish initialState =
   let
-    repo          = Config.repository projectConfig
-    runAll        = foldFree (runSum (runSum runMetrics runTime) (runSum runGit runGithub))
-    runAction     = foldFree (runSum (Logic.runBaseAction projectConfig) (Logic.runRetrieveEnvironment projectConfig))
+    repo             = Config.repository projectConfig
+    runAll           = foldFree (runSum (runSum runMetrics runTime) (runSum runGit runGithub))
+    runAction        = foldFree (runSum (Logic.runBaseAction projectConfig) (Logic.runRetrieveEnvironment projectConfig))
+    showState state' = fromRight (showText state') $ decodeUtf8' $ toStrict $ encode state'
     handleAndContinue state0 event = do
       -- Handle the event and then perform any additional required actions until
       -- the state reaches a fixed point (when there are no further actions to
       -- perform).
       logInfoN  $ "logic loop received event (" <> repo <> "): " <> showText event
-      logDebugN $ "state before (" <> repo <> "): " <> showText state0
+      logDebugN $ "state before (" <> repo <> "): " <> showState state0
       state1 <- runAll $ runAction $
         Logic.handleEvent triggerConfig mergeWindowExemptionConfig event state0
       publish state1
-      logDebugN $ "state after (" <> repo <> "): " <> showText state1
+      logDebugN $ "state after (" <> repo <> "): " <> showState state1
       runLoop state1
 
     runLoop state = do

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -20,6 +20,7 @@ module Git
   Branch (..),
   BaseBranch (..),
   CloneResult (..),
+  Context (..),
   GitOperation,
   GitOperationFree,
   GitIntegrationFailure (..),
@@ -63,7 +64,9 @@ import Control.Monad.Logger (MonadLogger, logInfoN, logWarnN)
 import Data.Aeson
 import Data.Either (isLeft)
 import Data.List (intersperse)
+import Data.String (IsString)
 import Data.Text (Text)
+import GHC.Generics (Generic)
 import System.Directory (doesDirectoryExist)
 import System.Environment (getEnvironment)
 import System.Exit (ExitCode (ExitSuccess))
@@ -78,7 +81,6 @@ import Configuration (UserConfiguration)
 import Format (format)
 
 import qualified Configuration as Config
-import GitHub.Internal.Prelude (Generic)
 
 -- | A branch is identified by its name.
 newtype Branch = Branch Text deriving newtype (Show, Eq)
@@ -99,7 +101,12 @@ toBaseBranch :: Branch -> BaseBranch
 toBaseBranch (Branch name) = BaseBranch name
 
 -- | A commit hash is stored as its hexadecimal representation.
-newtype Sha = Sha Text deriving newtype (Show, Eq)
+newtype Sha = Sha Text deriving newtype (Show, Eq, Ord, FromJSONKey, ToJSONKey)
+
+-- | The context a check occured in.
+newtype Context = Context Text
+  deriving newtype (Show, Eq, Ord, IsString)
+  deriving newtype (FromJSON, ToJSON, FromJSONKey, ToJSONKey)
 
 newtype RemoteUrl = RemoteUrl Text deriving newtype (Show, Eq)
 

--- a/src/Github.hs
+++ b/src/Github.hs
@@ -7,6 +7,8 @@
 
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Github
 (
@@ -33,7 +35,7 @@ import Data.Aeson.Types (Parser, typeMismatch)
 import Data.Text (Text)
 import GHC.Natural (Natural)
 
-import Git (Sha (..), Branch (..), BaseBranch (..))
+import Git (Sha (..), Branch (..), BaseBranch (..), Context)
 import Project (ProjectInfo (..))
 import Types (Username)
 import Data.Maybe (fromMaybe)
@@ -87,11 +89,12 @@ data CommentPayload = CommentPayload {
 } deriving (Eq, Show)
 
 data CommitStatusPayload = CommitStatusPayload {
-  owner      :: Text,         -- Corresponds to "repository.owner.login".
-  repository :: Text,         -- Corresponds to "repository.name".
-  status     :: CommitStatus, -- Corresponds to "action".
-  url        :: Maybe Text,   -- Corresponds to "target_url".
-  sha        :: Sha           -- Corresponds to "sha".
+  owner      :: Text,                -- Corresponds to "repository.owner.login".
+  repository :: Text,                -- Corresponds to "repository.name".
+  status     :: CommitStatus,        -- Corresponds to "action".
+  context    :: Context,             -- Corresponds to "context".
+  url        :: Maybe Text,          -- Corresponds to "target_url".
+  sha        :: Sha                  -- Corresponds to "sha".
 } deriving (Eq, Show)
 
 instance FromJSON PullRequestAction where
@@ -166,6 +169,7 @@ instance FromJSON CommitStatusPayload where
     <$> getNested v ["repository", "owner", "login"]
     <*> getNested v ["repository", "name"]
     <*> (v .: "state")
+    <*> (v .: "context")
     <*> (v .: "target_url")
     <*> (v .: "sha")
   parseJSON nonObject = typeMismatch "status payload" nonObject

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -190,7 +190,8 @@ buildProjectConfig repoDir stateFile = Config.ProjectConfiguration {
   Config.branch     = "master",
   Config.testBranch = "integration",
   Config.checkout   = repoDir,
-  Config.stateFile  = stateFile
+  Config.stateFile  = stateFile,
+  Config.checks     = Just (Config.ChecksConfiguration Set.empty)
 }
 
 -- Dummy user configuration used in test environment.
@@ -412,7 +413,7 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Add Leon test results" "deckard",
             Logic.CommentAdded pr4 "rachael" "@bot merge",
-            Logic.BuildStatusChanged c4 BuildSucceeded
+            Logic.BuildStatusChanged c4 "default" BuildSucceeded
           ]
       history `shouldBe`
         [ "* c4"
@@ -441,7 +442,7 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Add Leon test results" "deckard",
             Logic.CommentAdded pr4 "rachael" "@bot merge",
-            Logic.BuildStatusChanged c4 (BuildFailed Nothing)
+            Logic.BuildStatusChanged c4 "default" (BuildFailed Nothing)
           ]
       -- the build failed, so master's history is unchanged
       -- ... and the integration/4 branch is kept for inpection of the CI build
@@ -468,7 +469,7 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Deploy tests!" "deckard",
             Logic.CommentAdded pr4 "rachael" "@bot merge and tag",
-            Logic.BuildStatusChanged c4 BuildSucceeded
+            Logic.BuildStatusChanged c4 "default" BuildSucceeded
           ]
       history `shouldBe`
         [ "* c4"
@@ -522,7 +523,7 @@ eventLoopSpec = parallel $ do
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
       history `shouldBe`
         [ "*   Merge #4"
@@ -580,7 +581,7 @@ eventLoopSpec = parallel $ do
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
       history `shouldBe`
         [ "*   Merge #6"
@@ -617,7 +618,7 @@ eventLoopSpec = parallel $ do
 
         let [rebasedSha] = integrationShas state
 
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
       history `shouldBe`
         [ "*   Merge #6"
@@ -675,7 +676,7 @@ eventLoopSpec = parallel $ do
 
         let [rebasedSha] = integrationShas state
 
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
       history `shouldBe`
         [ "*   Merge #6"
@@ -739,12 +740,12 @@ eventLoopSpec = parallel $ do
 
         -- The rebased commit should have been pushed to the remote repository
         -- 'integration' branch. Tell that building it succeeded.
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
         -- Repeat for the other pull request, which should be the candidate by
         -- now.
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' "default" BuildSucceeded]
 
       history `shouldBe`
         [ "* c4"
@@ -778,10 +779,10 @@ eventLoopSpec = parallel $ do
 
         let [rebasedSha,_] = integrationShas state
 
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' "default" BuildSucceeded]
 
       history `shouldBe`
         [ "* c4"
@@ -866,7 +867,7 @@ eventLoopSpec = parallel $ do
         let Just pullRequest4 = Project.lookupPullRequest pr4 state
             Integrated _ buildStatus = Project.integrationStatus pullRequest4
         -- Expect no CI url
-        buildStatus `shouldBe` BuildPending
+        buildStatus `shouldBe` (Project.AnyCheck BuildPending)
 
       -- We did not send a build status notification for c4, so it should not
       -- have been integrated.
@@ -903,7 +904,7 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
         -- The push should have failed, hence there should still be an
         -- integration candidate.
@@ -911,7 +912,7 @@ eventLoopSpec = parallel $ do
 
         -- Again notify build success, now for the new commit.
         let [rebasedSha'] = integrationShas state'
-        state'' <- runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        state'' <- runLoop state' [Logic.BuildStatusChanged rebasedSha' "default" BuildSucceeded]
 
         -- After the second build success, the pull request should have been
         -- integrated properly, so there should not be a new candidate.
@@ -954,11 +955,11 @@ eventLoopSpec = parallel $ do
         git ["push", "origin", refSpec (c4, masterBranch)]
 
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' "default" BuildSucceeded]
 
         -- After the second build success, the pull request should have been
         -- integrated properly, version should be incremented only once
@@ -1026,11 +1027,11 @@ eventLoopSpec = parallel $ do
         git ["push", "origin", refSpec (Git.TagName "v2")]
 
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' "default" BuildSucceeded]
 
         -- After the second build success, the pull request should have been integrated properly,
         -- version should be incremented only once, and follow version that appeared in the meantime
@@ -1095,7 +1096,7 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let [rebasedSha] = integrationShas state
-        void $ runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        void $ runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
       -- now c8 is the last commit, and there are no others. Note that if the
@@ -1135,11 +1136,11 @@ eventLoopSpec = parallel $ do
         -- Extract the sha of the rebased commit from the project state, and
         -- tell the loop that building the commit succeeded.
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
         -- Again notify build success, now for the new commit.
         let [rebasedSha'] = integrationShas state'
-        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' BuildSucceeded]
+        void $ runLoop state' [Logic.BuildStatusChanged rebasedSha' "default" BuildSucceeded]
 
       -- We expect the fixup commit (which was last) to be squashed into c7, so
       -- now c8 is the last commit, and there are no others. This time c4 and c5
@@ -1185,7 +1186,7 @@ eventLoopSpec = parallel $ do
         -- tell the loop that building the commit succeeded.
 
         let [rebasedSha] = integrationShas state
-        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha BuildSucceeded]
+        state' <- runLoop state [Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded]
 
         --The pull request should not be integrated. Moreover, the presence of
         --orphan fixups should make the PR ineligible for being a candidate for integration.
@@ -1227,7 +1228,7 @@ eventLoopSpec = parallel $ do
 
         state' <- runLoop state
           [
-            Logic.BuildStatusChanged rebasedSha BuildSucceeded,
+            Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded,
             Logic.CommentAdded pr6 "rachael" "@bot merge"
           ]
 

--- a/tests/ProjectSpec.hs
+++ b/tests/ProjectSpec.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module ProjectSpec (projectSpec) where
+
+import Control.Monad (forM_)
+import Test.Hspec (Spec, describe, shouldBe, shouldNotBe, shouldSatisfy)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck ((==>), Arbitrary, genericShrink)
+import Test.QuickCheck.Arbitrary (arbitrary, shrink)
+import Test.QuickCheck.Arbitrary.Generic (genericArbitrary)
+import Test.QuickCheck.Instances.Text ()
+
+import qualified Data.Map.Strict as Map
+
+import qualified Project
+
+projectSpec :: Spec
+projectSpec = do
+  describe "Project.subMapByOwner" $ do
+    prop "the ord instance guarentees owners are grouped together" $ \(owners, repositories) -> do
+      let projectInfos = [Project.ProjectInfo owner repo | owner <- owners, repo <- repositories]
+          projectInfoMap = Map.fromList (map (\p -> (p, Project.repository p)) projectInfos)
+
+      forM_ owners $ \owner -> do
+        Project.subMapByOwner owner projectInfoMap `shouldBe`
+          Map.filterWithKey (\key _ -> Project.owner key == owner) projectInfoMap
+
+  describe "Project.summarize" $ do
+    prop "Ensure successes are always overshadowed by other statuses" $ \statuses -> do
+      let outstanding = Project.SpecificChecks $ Map.fromList statuses
+      any ((/= Project.BuildSucceeded) . snd) statuses ==> do
+        Project.summarize outstanding `shouldNotBe` Project.BuildSucceeded
+    prop "Ensure failures always overshadow other statuses" $ \statuses -> do
+      let outstanding = Project.SpecificChecks $ Map.fromList statuses
+          isFailure (Project.BuildFailed _) = True
+          isFailure _ = False
+      any (isFailure . snd) statuses ==> do
+        Project.summarize outstanding `shouldSatisfy` isFailure
+
+instance Arbitrary Project.Check where
+  arbitrary = Project.Check <$> arbitrary
+instance Arbitrary Project.BuildStatus where
+  arbitrary = genericArbitrary
+  shrink = genericShrink

--- a/tools/send-webhook
+++ b/tools/send-webhook
@@ -44,6 +44,10 @@ To simulated a failed or error build status, use:
 
     ./tools/build-status c033170123456789abcdef0123456789abcdef01 error
 
+Optionally provide a context for the status:
+
+    ./tools/build-status c033170123456789abcdef0123456789abcdef01 error https://example.com context
+
 The secret and owner/repository are figured out from your config.json.
 Current setting: $owner/$repository
 USAGE
@@ -93,6 +97,7 @@ cat <<JSON
 		"name": "$repository"
 	},
 	"sha": "$commit",
+	"context": "$context",
 	"state": "$state",
 	"target_url": $target
 }
@@ -125,6 +130,7 @@ build-status)
 	commit="$1"
 	state="$2"
 	target="$3"
+	context="${4:-default}"
 
 	[ -n "$commit" ] || errxit "Full commit sha should be provided as the 1st argument"
 	[ -n "$state" ] || state=success


### PR DESCRIPTION
Add option to specify mandatory checks that need to be satisfied before merging.
- In the `config.json` it is now possible to add mandatory checks per project via a `"checks" -> "mandatory"` path.
- Each commit status update specifies a mandatory `context` key that is now parsed, see [here](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#status).
- If context satisfies the check, by the check being the prefix of the given context, its status is added to the integration of that commit.
- Once all mandatory checks have succeeded, the PR is merged.

As an aside, I also updated the thread initialization to use `Map` instead of `[]`. Though I'm open to dropping this change considering it doesn't do much if all repositories have the same owner.