### PR TITLE
Add 'merge and deploy to <env>' command

### DIFF
--- a/doc/example-dev-config.json
+++ b/doc/example-dev-config.json
@@ -8,7 +8,11 @@
     "stateFile": "./run/state/git-sandbox.json",
     "checks": {
       "mandatory": []
-    }
+    },
+    "deployEnvironments": [
+      "staging",
+      "production"
+    ]
   }],
   "secret": "REPLACE with output of 'head --bytes 32 /dev/urandom | base64'",
   "accessToken": "REPLACE with a new personal access token from https://github.com/settings/tokens",

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -8,7 +8,11 @@
     "stateFile": "/var/lib/hoff/state/your-username/your-repo.json",
     "checks": {
       "mandatory": []
-    }
+    },
+    "deployEnvironments": [
+      "staging",
+      "production"
+    ]
   }],
   "secret": "run 'head --bytes 32 /dev/urandom | base64' and paste output here",
   "accessToken": "paste a personal access token for a bot user here",

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,8 @@ following commands:
 
 * `@hoffbot merge`: rebase then merge;
 * `@hoffbot merge and tag`: rebase, merge then tag.
-* `@hoffbot merge and deploy`: rebase, merge, tag then deploy;
+* `@hoffbot merge and deploy`: rebase, merge, tag then deploy to the default environment;
+* `@hoffbot merge and deploy to <env>`: rebase, merge, tag then deploy to the specified environment;
 
 For all the commands, Hoff will wait for the builds to pass after rebasing and
 before merging.  When the PR is merged, GitHub closes the PR as merged and,

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -31,13 +31,14 @@ import qualified Network.Wai.Handler.Warp as Warp
 
 data ProjectConfiguration = ProjectConfiguration
   {
-    owner      :: Text,       -- The GitHub user or organization who owns the repo.
-    repository :: Text,       -- The name of the repository.
-    branch     :: Text,       -- The branch to guard and integrate commits into.
-    testBranch :: Text,       -- The branch to force-push candidates to for testing.
-    checkout   :: FilePath,   -- The path to a local checkout of the repository.
-    stateFile  :: FilePath,   -- The file where project state is stored.
-    checks     :: Maybe ChecksConfiguration -- Optional configuration related to checks for the project.
+    owner              :: Text,                      -- The GitHub user or organization who owns the repo.
+    repository         :: Text,                      -- The name of the repository.
+    branch             :: Text,                      -- The branch to guard and integrate commits into.
+    testBranch         :: Text,                      -- The branch to force-push candidates to for testing.
+    checkout           :: FilePath,                  -- The path to a local checkout of the repository.
+    stateFile          :: FilePath,                  -- The file where project state is stored.
+    checks             :: Maybe ChecksConfiguration, -- Optional configuration related to checks for the project.
+    deployEnvironments :: Maybe [Text]               -- The environments which the `deploy to <environment>` command should be enabled for
   }
   deriving (Generic)
 

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -67,7 +67,7 @@ import qualified Data.Text.Lazy.Builder.Int as B
 import qualified Data.Text.Read as Text
 import Data.Time (UTCTime, DayOfWeek (Friday), dayOfWeek, utctDay)
 
-import Configuration (ProjectConfiguration (owner, repository), TriggerConfiguration, MergeWindowExemptionConfiguration)
+import Configuration (ProjectConfiguration (owner, repository, deployEnvironments), TriggerConfiguration, MergeWindowExemptionConfiguration)
 import Format (format)
 import Git (Branch (..), BaseBranch (..), GitOperation, GitOperationFree, PushResult (..),
             GitIntegrationFailure (..), Sha (..), SomeRefSpec (..), TagMessage (..), TagName (..),
@@ -75,7 +75,7 @@ import Git (Branch (..), BaseBranch (..), GitOperation, GitOperationFree, PushRe
 
 import GithubApi (GithubOperation, GithubOperationFree)
 import Metrics.Metrics (MetricsOperationFree, MetricsOperation, increaseMergedPRTotal, updateTrainSizeGauge)
-import Project (Approval (..), ApprovedFor (..), BuildStatus (..), Check (..), IntegrationStatus (..),
+import Project (Approval (..), ApprovedFor (..), BuildStatus (..), Check (..), DeployEnvironment (..), IntegrationStatus (..),
                 MergeWindow(..), ProjectState, PullRequest, PullRequestStatus (..),
                 summarize, supersedes)
 import Time (TimeOperation, TimeOperationFree)
@@ -504,6 +504,7 @@ data ParseResult a
   -- | The parser decided to ignore the message because it did
   -- not contain a valid prefix.
   | Ignored
+  deriving (Show)
 
 -- Checks whether the parse result was valid.
 isSuccess :: ParseResult a -> Bool
@@ -517,8 +518,8 @@ isSuccess _ = False
 -- Returns `Ignored` if the bot was not mentioned, `Success` if it was mentioned
 -- in the same message as a valid command, and `Unknown` if it was mentioned but
 -- no valid command was found.
-parseMergeCommand :: TriggerConfiguration -> Text -> ParseResult (ApprovedFor, MergeWindow)
-parseMergeCommand config message =
+parseMergeCommand :: ProjectConfiguration -> TriggerConfiguration -> Text -> ParseResult (ApprovedFor, MergeWindow)
+parseMergeCommand projectConfig triggerConfig message =
   let
     normalise :: Text -> Text
     normalise msg =
@@ -528,29 +529,37 @@ parseMergeCommand config message =
       in Text.toCaseFold multiWhitespaceStripped
 
     messageNormalised = normalise message
-    prefixNormalised = normalise $ Config.commentPrefix config
+    prefixNormalised = normalise $ Config.commentPrefix triggerConfig
     mentioned = prefixNormalised `Text.isPrefixOf` messageNormalised
     -- Determines if any individual mention matches the given command message
     matchWith :: Text -> Bool
     matchWith msg = any (Text.isPrefixOf msg) mentions
       where mentions = Text.splitOn prefixNormalised messageNormalised
-    -- Check if the prefix followed by ` merge [and {deploy,tag}] [on friday]` occurs within the message.
-    -- We opt to include the space here, instead of making it part of the
-    -- prefix, because having the trailing space in config is something that is
-    -- easy to get wrong.
-    -- Note that because "merge" is an infix of "merge and xxx" we need to
-    -- check for the "merge and xxx" commands first: if this order were
-    -- reversed all "merge and xxx" commands would be detected as a Merge
-    -- command.
-    cases =
-      [ (" merge and deploy on friday", (MergeAndDeploy, OnFriday)),
-        (" merge and deploy", (MergeAndDeploy, NotFriday)),
-        (" merge and tag on friday", (MergeAndTag, OnFriday)),
-        (" merge and tag", (MergeAndTag, NotFriday)),
-        (" merge on friday", (Merge, OnFriday)),
-        (" merge", (Merge, NotFriday))
-      ]
-   in case listToMaybe [ cmd | (msg, cmd) <- cases, matchWith msg ] of
+
+    deployCommands :: [(Text, ApprovedFor)]
+    deployCommands = case deployEnvironments projectConfig of
+      Nothing     -> []
+      Just []     -> []
+      Just (e:es) -> map (\y -> (format " merge and deploy to {}" [y], MergeAndDeploy (DeployEnvironment y))) (e:es)
+                       ++ [(" merge and deploy", MergeAndDeploy $ DeployEnvironment e)]
+
+    defaultCommands :: [(Text, ApprovedFor)]
+    defaultCommands = [(" merge and tag", MergeAndTag),(" merge", Merge)]
+
+    -- Check if the prefix followed by ` merge [and {deploy,tag} [to
+    -- <environment>]] [on friday]` occurs within the message. We opt to include
+    -- the space here, instead of making it part of the prefix, because having
+    -- the trailing space in config is something that is easy to get wrong. Note
+    -- that because "merge" is an infix of "merge and xxx" we need to check for
+    -- the "merge and xxx" commands first: if this order were reversed all
+    -- "merge and xxx" commands would be detected as a Merge command. This
+    -- strict order requirement also holds for the `to <environment>` and `on
+    -- Friday` options
+    commands :: [(Text, (ApprovedFor, MergeWindow))]
+    commands = (\(cmd, af) (cont, mw) -> (Text.append cmd cont, (af, mw))) <$>
+      deployCommands ++ defaultCommands <*> [(" on friday", OnFriday), ("", NotFriday)]
+
+   in case listToMaybe [ cmd | (msg, cmd) <- commands, matchWith msg ] of
      Just command -> Success command
      Nothing | mentioned -> Unknown message
              | otherwise -> Ignored
@@ -580,7 +589,9 @@ handleCommentAdded triggerConfig mergeWindowExemption prId author body state =
     -- frequently, but most comments are not merge commands, and checking that
     -- a user has push access requires an API call.
     Just pr -> do
-      let commandType = parseMergeCommand triggerConfig body
+      projectConfig <- getProjectConfig
+
+      let commandType = parseMergeCommand projectConfig triggerConfig body
           exempted :: Username -> Bool
           exempted (Username user) =
             let (Config.MergeWindowExemptionConfiguration users) = mergeWindowExemption
@@ -593,7 +604,6 @@ handleCommentAdded triggerConfig mergeWindowExemption prId author body state =
       -- For now Friday at UTC+0 is good enough.
       -- See https://github.com/channable/hoff/pull/95 for caveats and improvement ideas.
       day <- dayOfWeek . utctDay <$> getDateTime
-      projectConfig <- getProjectConfig
       case commandType of
         -- The bot was not mentioned in the comment, ignore
         Ignored -> pure state
@@ -845,8 +855,13 @@ tryIntegratePullRequest pr state =
       [ format "Merge #{}: {}" (prNumber, title)
       , ""
       , format "Approved-by: {}" [approvedBy]
-      , format "Auto-deploy: {}" [if approvalType == MergeAndDeploy then "true" else "false" :: Text]
-      ]
+      ] ++
+        case approvalType of
+          MergeAndDeploy (DeployEnvironment env) ->
+            [ "Auto-deploy: true"
+            , format "Deploy-Environment: {}" [env]]
+          _ -> [ "Auto-deploy: false" ]
+
     mergeMessage = Text.unlines mergeMessageLines
     -- the takeWhile here is needed in case of reintegrations after failing pushes
     train = takeWhile (/= pr) $ Pr.unfailedIntegratedPullRequests state

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -185,13 +185,14 @@ initializeRepository originDir repoDir = do
 -- Generate a project configuration to be used in the test environment.
 buildProjectConfig :: FilePath -> FilePath -> ProjectConfiguration
 buildProjectConfig repoDir stateFile = Config.ProjectConfiguration {
-  Config.owner      = "ruuda",
-  Config.repository = "blog",
-  Config.branch     = "master",
-  Config.testBranch = "integration",
-  Config.checkout   = repoDir,
-  Config.stateFile  = stateFile,
-  Config.checks     = Just (Config.ChecksConfiguration Set.empty)
+  Config.owner              = "ruuda",
+  Config.repository         = "blog",
+  Config.branch             = "master",
+  Config.testBranch         = "integration",
+  Config.checkout           = repoDir,
+  Config.stateFile          = stateFile,
+  Config.checks             = Just (Config.ChecksConfiguration Set.empty),
+  Config.deployEnvironments = Just ["staging", "production"]
 }
 
 -- Dummy user configuration used in test environment.


### PR DESCRIPTION
This adds a `merge and deploy to <environment>` command to Hoff, where the possible choices of <environment> can be configured per repository. 
If no environments are specified `merge and deploy` is disabled for that repository.
The specified environment is set as `Deploy-Environment: <environment>` in the merge commit message (but only if `Auto-Deploy` is set to true)
The existing `merge and deploy` command still works, and sets the first environment specified in the repository configuration as the `Deploy-Environment`.

Note that the current approach has a few minor drawbacks:
- `merge and deploy to porduction` (or some other misspelling of the environment name) will match with `merge and deploy` instead, and fall back to the default environment. We could parse more greedily, but this requires a larger rewrite.
- Setting `deployEnvironments` is required, so the configuration isn't backwards compatible. Making `deployEnvironments` optional comes with a incompatibility too, as currently the `merge and deploy` is always enabled.