### PR TITLE
Link to correct tag page

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -925,7 +925,7 @@ pushCandidate (pullRequestId, pullRequest) newHead@(Sha sha) state =
               case tagResult of
                 Left err -> "Sorry, I could not tag your PR. " <> err
                 Right (TagName t) -> do
-                  let link = format "[{}](https://github.com/{}/{}/tags/{})" (t, owner config, repository config, t)
+                  let link = format "[{}](https://github.com/{}/{}/releases/tags/{})" (t, owner config, repository config, t)
                   "I tagged your PR with " <> link <> ". " <>
                     if Pr.needsDeploy approvalKind
                     then "It is scheduled for autodeploy!"

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1313,7 +1313,7 @@ main = hspec $ do
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
         candidates = getIntegrationCandidates state'
         sha = "38e"
-        tagMessage = format "@deckard I tagged your PR with [v2](https://github.com/{}/{}/tags/v2). "
+        tagMessage = format "@deckard I tagged your PR with [v2](https://github.com/{}/{}/releases/tags/v2). "
                             (Config.owner testProjectConfig, Config.repository testProjectConfig)
         commitMessage = format "Please wait for the build of {} to pass and don't forget to deploy it!"
                                (Only { fromOnly = sha })
@@ -1350,7 +1350,7 @@ main = hspec $ do
           }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
         candidates = getIntegrationCandidates state'
-        tagMessage = format "@deckard I tagged your PR with [v2](https://github.com/{}/{}/tags/v2). "
+        tagMessage = format "@deckard I tagged your PR with [v2](https://github.com/{}/{}/releases/tags/v2). "
                             (Config.owner testProjectConfig, Config.repository testProjectConfig)
       -- After a successful push, the candidate should be gone.
       candidates `shouldBe` []


### PR DESCRIPTION
This fixes the url to the github releases page

For example: https://github.com/channable/hoff/tag/v0.27.3 vs https://github.com/channable/hoff/releases/tag/v0.27.3