### PR TITLE
Update nixpkgs to nixpkgs-unstable

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -74,7 +74,7 @@ blocks:
             # [1]: https://hackage.haskell.org/package/unexceptionalio-0.3.0/src/COPYING.
             # [2]: https://hackage.haskell.org/package/monad-loops-0.4.3
             # [3]: https://hackage.haskell.org/package/http-link-header-1.2.0
-            - "! stack ls dependencies --license | egrep -v 'Apache-2|BSD-?2|BSD-?3|MIT|ISC|PublicDomain|MPL-2.0|unexceptionalio|http-link-header|monad-loops'"
+            - "! stack ls dependencies --license | egrep -v 'Apache-2|BSD-?2|BSD-?3|MIT|ISC|PublicDomain|MPL-2.0|unexceptionalio|http-link-header|monad-loops|data-sketches'"
 
             # Check shell scripts for issues.
             - "shellcheck package/*.sh package/deb-postinst"

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@ let
       pkgs.dpkg
       pkgs.git
       pkgs.haskellPackages.haskell-language-server
+      pkgs.haskellPackages.ghc # Needed for the language server
       pkgs.haskellPackages.stylish-haskell
       pkgs.niv
       pkgs.shellcheck

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-21.05",
+        "branch": "nixpkgs-unstable",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
-        "sha256": "11d9m0c4r4kpr3jx3cqblw6ld4d8dwcfv1lk68ipp4c87knwv7fb",
+        "rev": "f2e9a130461950270f87630b11132323706b4d91",
+        "sha256": "05qz5q9igl3095wncj493kkqdpdl2qahycbsz77dhh7rfy16n5cg",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/530a53dcbc9437363471167a5e4762c5fcfa34a1.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f2e9a130461950270f87630b11132323706b4d91.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -6,8 +6,8 @@
 -- A copy of the License has been included in the root of the repository.
 
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RankNTypes #-}
 
 module EventLoop
@@ -51,27 +51,27 @@ import qualified Metrics.Metrics as Metrics
 eventFromPullRequestPayload :: PullRequestPayload -> Logic.Event
 eventFromPullRequestPayload payload =
   let
-    number = Github.number (payload :: PullRequestPayload) -- TODO: Use PullRequestId wrapper from beginning.
-    title  = Github.title  (payload :: PullRequestPayload)
-    author = Github.author (payload :: PullRequestPayload)
-    branch = Github.branch (payload :: PullRequestPayload)
-    sha    = Github.sha    (payload :: PullRequestPayload)
+    number = PullRequestId payload.number
+    title  = payload.title
+    author = payload.author
+    branch = payload.branch
+    sha    = payload.sha
     baseBranch = Github.baseBranch (payload :: PullRequestPayload)
   in
-    case Github.action (payload :: PullRequestPayload) of
-      Github.Opened      -> Logic.PullRequestOpened (PullRequestId number) branch baseBranch sha title author
-      Github.Reopened    -> Logic.PullRequestOpened (PullRequestId number) branch baseBranch sha title author
-      Github.Closed      -> Logic.PullRequestClosed (PullRequestId number)
-      Github.Synchronize -> Logic.PullRequestCommitChanged (PullRequestId number) sha
-      Github.Edited      -> Logic.PullRequestEdited (PullRequestId number) title baseBranch
+    case payload.action of
+      Github.Opened      -> Logic.PullRequestOpened number branch baseBranch sha title author
+      Github.Reopened    -> Logic.PullRequestOpened number branch baseBranch sha title author
+      Github.Closed      -> Logic.PullRequestClosed number
+      Github.Synchronize -> Logic.PullRequestCommitChanged number sha
+      Github.Edited      -> Logic.PullRequestEdited number title baseBranch
 
 eventFromCommentPayload :: CommentPayload -> Maybe Logic.Event
 eventFromCommentPayload payload =
-  let number = Github.number (payload :: CommentPayload) -- TODO: Use PullRequestId wrapper from beginning.
-      author = Github.author (payload :: CommentPayload) -- TODO: Wrapper type
-      body   = Github.body   (payload :: CommentPayload)
-      commentAdded = Logic.CommentAdded (PullRequestId number) author body
-  in case Github.action (payload :: CommentPayload) of
+  let number = PullRequestId payload.number
+      author = payload.author -- TODO: Wrapper type
+      body   = payload.body
+      commentAdded = Logic.CommentAdded number author body
+  in case payload.action of
     Left Github.CommentCreated -> Just commentAdded
     Right Github.ReviewSubmitted -> Just commentAdded
     -- Do not bother with edited and deleted comments, as it would tremendously
@@ -91,10 +91,10 @@ mapCommitStatus status murl = case status of
 
 eventFromCommitStatusPayload :: CommitStatusPayload -> Logic.Event
 eventFromCommitStatusPayload payload =
-  let sha     = Github.sha     (payload :: CommitStatusPayload)
-      status  = Github.status  (payload :: CommitStatusPayload)
-      url     = Github.url     (payload :: CommitStatusPayload)
-      context = Github.context (payload :: CommitStatusPayload)
+  let sha     = payload.sha
+      status  = payload.status
+      url     = payload.url
+      context = payload.context
   in  Logic.BuildStatusChanged sha context (mapCommitStatus status url)
 
 convertGithubEvent :: Github.WebhookEvent -> Maybe Logic.Event

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@
 # Via nix (see `nix.shell-file` down below), we provide a GHC that comes
 # with all the packages we need. Therefore, stack does not have to
 # download or build any snapshot packages, they all come directly from nixpkgs.
-resolver: ghc-8.10
+resolver: ghc-9.2
 
 # This makes stack pick up our nix environment for building by default.
 nix:

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 -- Hoff -- A gatekeeper for your commits
 -- Copyright 2016 Ruud van Asseldonk
 --

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,4 +1,5 @@
--- Hofww
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+-- Hoff
 -- A gatekeeper for your commits
 -- Copyright 2016 Ruud van Asseldonk
 --
@@ -9,6 +10,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE TupleSections #-}
 
 import Control.Monad.Free (foldFree)
@@ -1630,25 +1632,16 @@ main = hspec $ do
       let maybePayload :: Maybe PullRequestPayload
           maybePayload = decode examplePayload
       maybePayload `shouldSatisfy` isJust
-      let payload    = fromJust maybePayload
-          action     = Github.action     (payload :: PullRequestPayload)
-          owner      = Github.owner      (payload :: PullRequestPayload)
-          repository = Github.repository (payload :: PullRequestPayload)
-          number     = Github.number     (payload :: PullRequestPayload)
-          headSha    = Github.sha        (payload :: PullRequestPayload)
-          title      = Github.title      (payload :: PullRequestPayload)
-          prAuthor   = Github.author     (payload :: PullRequestPayload)
-          prBranch   = Github.branch     (payload :: PullRequestPayload)
-          baseBranch = Github.baseBranch (payload :: PullRequestPayload)
-      action     `shouldBe` Github.Opened
-      owner      `shouldBe` "baxterthehacker"
-      repository `shouldBe` "public-repo"
-      number     `shouldBe` 1
-      headSha    `shouldBe` (Sha "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c")
-      prBranch   `shouldBe` (Branch "changes")
-      baseBranch `shouldBe` masterBranch
-      title      `shouldBe` "Update the README with new information"
-      prAuthor   `shouldBe` "baxterthehacker2"
+      let payload       = fromJust maybePayload
+      payload.action     `shouldBe` Github.Opened
+      payload.owner      `shouldBe` "baxterthehacker"
+      payload.repository `shouldBe` "public-repo"
+      payload.number     `shouldBe` 1
+      payload.sha        `shouldBe` (Sha "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c")
+      payload.branch     `shouldBe` (Branch "changes")
+      payload.baseBranch `shouldBe` masterBranch
+      payload.title      `shouldBe` "Update the README with new information"
+      payload.author     `shouldBe` "baxterthehacker2"
 
 
     it "parses a CommentPayload from a created issue_comment correctly" $ do
@@ -1657,18 +1650,12 @@ main = hspec $ do
           maybePayload = decode examplePayload
       maybePayload `shouldSatisfy` isJust
       let payload       = fromJust maybePayload
-          action        = Github.action     (payload :: CommentPayload)
-          owner         = Github.owner      (payload :: CommentPayload)
-          repository    = Github.repository (payload :: CommentPayload)
-          number        = Github.number     (payload :: CommentPayload)
-          commentAuthor = Github.author     (payload :: CommentPayload)
-          commentBody   = Github.body       (payload :: CommentPayload)
-      action        `shouldBe` Left Github.CommentCreated
-      owner         `shouldBe` "baxterthehacker"
-      repository    `shouldBe` "public-repo"
-      number        `shouldBe` 2
-      commentAuthor `shouldBe` "baxterthehacker2"
-      commentBody   `shouldBe` "You are totally right! I'll get this fixed right away."
+      payload.action        `shouldBe` Left Github.CommentCreated
+      payload.owner         `shouldBe` "baxterthehacker"
+      payload.repository    `shouldBe` "public-repo"
+      payload.number        `shouldBe` 2
+      payload.author        `shouldBe` "baxterthehacker2"
+      payload.body          `shouldBe` "You are totally right! I'll get this fixed right away."
 
     it "parses a CommentPayload from an edited issue_comment correctly" $ do
       examplePayload <- readFile "tests/data/issue-comment-edited-payload.json"
@@ -1676,18 +1663,12 @@ main = hspec $ do
           maybePayload = decode examplePayload
       maybePayload `shouldSatisfy` isJust
       let payload       = fromJust maybePayload
-          action        = Github.action     (payload :: CommentPayload)
-          owner         = Github.owner      (payload :: CommentPayload)
-          repository    = Github.repository (payload :: CommentPayload)
-          number        = Github.number     (payload :: CommentPayload)
-          commentAuthor = Github.author     (payload :: CommentPayload)
-          commentBody   = Github.body       (payload :: CommentPayload)
-      action        `shouldBe` Left Github.CommentEdited
-      owner         `shouldBe` "crtschin"
-      repository    `shouldBe` "test"
-      number        `shouldBe` 1
-      commentAuthor `shouldBe` "crtschin"
-      commentBody   `shouldBe` "This is an edit of a comment on the issue page."
+      payload.action        `shouldBe` Left Github.CommentEdited
+      payload.owner         `shouldBe` "crtschin"
+      payload.repository    `shouldBe` "test"
+      payload.number        `shouldBe` 1
+      payload.author        `shouldBe` "crtschin"
+      payload.body          `shouldBe` "This is an edit of a comment on the issue page."
 
     it "parses a CommentPayload from a submitted pull_request_review correctly" $ do
       examplePayload <- readFile "tests/data/pull-request-review-submitted-payload.json"
@@ -1695,18 +1676,12 @@ main = hspec $ do
           maybePayload = decode examplePayload
       maybePayload `shouldSatisfy` isJust
       let payload       = fromJust maybePayload
-          action        = Github.action     (payload :: CommentPayload)
-          owner         = Github.owner      (payload :: CommentPayload)
-          repository    = Github.repository (payload :: CommentPayload)
-          number        = Github.number     (payload :: CommentPayload)
-          commentAuthor = Github.author     (payload :: CommentPayload)
-          commentBody   = Github.body       (payload :: CommentPayload)
-      action        `shouldBe` Right Github.ReviewSubmitted
-      owner         `shouldBe` "crtschin"
-      repository    `shouldBe` "test"
-      number        `shouldBe` 1
-      commentAuthor `shouldBe` "crtschin"
-      commentBody   `shouldBe` "This is the finalization comment on the pull request review page."
+      payload.action        `shouldBe` Right Github.ReviewSubmitted
+      payload.owner         `shouldBe` "crtschin"
+      payload.repository    `shouldBe` "test"
+      payload.number        `shouldBe` 1
+      payload.author        `shouldBe` "crtschin"
+      payload.body          `shouldBe` "This is the finalization comment on the pull request review page."
 
     it "parses a CommentPayload from a edited pull_request_review correctly" $ do
       examplePayload <- readFile "tests/data/pull-request-review-edited-payload.json"
@@ -1714,18 +1689,12 @@ main = hspec $ do
           maybePayload = decode examplePayload
       maybePayload `shouldSatisfy` isJust
       let payload       = fromJust maybePayload
-          action        = Github.action     (payload :: CommentPayload)
-          owner         = Github.owner      (payload :: CommentPayload)
-          repository    = Github.repository (payload :: CommentPayload)
-          number        = Github.number     (payload :: CommentPayload)
-          commentAuthor = Github.author     (payload :: CommentPayload)
-          commentBody   = Github.body       (payload :: CommentPayload)
-      action        `shouldBe` Right Github.ReviewEdited
-      owner         `shouldBe` "crtschin"
-      repository    `shouldBe` "test"
-      number        `shouldBe` 1
-      commentAuthor `shouldBe` "crtschin"
-      commentBody   `shouldBe` "This is an edit of the finalization comment of the review on the issue page."
+      payload.action        `shouldBe` Right Github.ReviewEdited
+      payload.owner         `shouldBe` "crtschin"
+      payload.repository    `shouldBe` "test"
+      payload.number        `shouldBe` 1
+      payload.author        `shouldBe` "crtschin"
+      payload.body          `shouldBe` "This is an edit of the finalization comment of the review on the issue page."
 
     it "parses a CommitStatusPayload correctly" $ do
       examplePayload <- readFile "tests/data/status-payload.json"
@@ -1733,16 +1702,11 @@ main = hspec $ do
           maybePayload = decode examplePayload
       maybePayload `shouldSatisfy` isJust
       let payload       = fromJust maybePayload
-          owner         = Github.owner      (payload :: CommitStatusPayload)
-          repository    = Github.repository (payload :: CommitStatusPayload)
-          status        = Github.status     (payload :: CommitStatusPayload)
-          url           = Github.url        (payload :: CommitStatusPayload)
-          commitSha     = Github.sha        (payload :: CommitStatusPayload)
-      owner      `shouldBe` "baxterthehacker"
-      repository `shouldBe` "public-repo"
-      status     `shouldBe` Github.Success
-      url        `shouldBe` Nothing
-      commitSha  `shouldBe` (Sha "9049f1265b7d61be4a8904a9a27120d2064dab3b")
+      payload.owner      `shouldBe` "baxterthehacker"
+      payload.repository `shouldBe` "public-repo"
+      payload.status     `shouldBe` Github.Success
+      payload.url        `shouldBe` Nothing
+      payload.sha        `shouldBe` (Sha "9049f1265b7d61be4a8904a9a27120d2064dab3b")
 
   describe "Configuration" $ do
 


### PR DESCRIPTION
I was looking into doing some hobby related things for hoff, and found that nixpkgs was still on release-21.05. That's pretty old, so I updated it to the latest `nixpkgs-unstable`.

Some changes:

- The default `haskellPackages` is `9.2.7`, up from `8.10`
- Aeson switched from using `Text` as keys, to a separate `Key` type
- GHC doesn't like `ambiguousRecordFunction (foo :: TypeOfRecord)` anymore and warns about it being ambiguous. `OverloadedRecordDot` is a nice alternative here.
- The tests make extensive use of pattern match assumptions. GHC now warns about these being incomplete pattern matches. Instead of fixing them all, I (for now) just chose to ignore the warning.
- `haskell-language-server` cannot find out which version of GHC the project uses, unless GHC is in path. So I added it to `default.nix`.
- One new transitive dependency (`data-sketches`) has a license that stack marks as unknown. It's [Apache](https://hackage.haskell.org/package/data-sketches-0.3.1.0/src/LICENSE).