### PR TITLE
Fix typo `releases/tags/` to `releases/tag/`

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -1031,7 +1031,7 @@ pushCandidate (pullRequestId, pullRequest) newHead@(Sha sha) state =
               case tagResult of
                 Left err -> "Sorry, I could not tag your PR. " <> err
                 Right (TagName t) -> do
-                  let link = format "[{}](https://github.com/{}/{}/releases/tags/{})" (t, owner config, repository config, t)
+                  let link = format "[{}](https://github.com/{}/{}/releases/tag/{})" (t, owner config, repository config, t)
                   "I tagged your PR with " <> link <> ". " <>
                     if Pr.needsDeploy approvalKind
                     then "It is scheduled for autodeploy!"

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1436,7 +1436,7 @@ main = hspec $ do
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
         candidates = getIntegrationCandidates state'
         sha = "38e"
-        tagMessage = format "@deckard I tagged your PR with [v2](https://github.com/{}/{}/releases/tags/v2). "
+        tagMessage = format "@deckard I tagged your PR with [v2](https://github.com/{}/{}/releases/tag/v2). "
                             (Config.owner testProjectConfig, Config.repository testProjectConfig)
         commitMessage = format "Please wait for the build of {} to pass and don't forget to deploy it!"
                                (Only { fromOnly = sha })
@@ -1473,7 +1473,7 @@ main = hspec $ do
           }
         (state', actions) = runActionCustom results $ Logic.proceedUntilFixedPoint state
         candidates = getIntegrationCandidates state'
-        tagMessage = format "@deckard I tagged your PR with [v2](https://github.com/{}/{}/releases/tags/v2). "
+        tagMessage = format "@deckard I tagged your PR with [v2](https://github.com/{}/{}/releases/tag/v2). "
                             (Config.owner testProjectConfig, Config.repository testProjectConfig)
       -- After a successful push, the candidate should be gone.
       candidates `shouldBe` []


### PR DESCRIPTION
The url that linked to specific tags had a typo in it. The correct url is `https://github.com/{}/{}/releases/tag/{}` not `https://github.com/{}/{}/releases/tags/{}`.


e.g:
Correct: https://github.com/channable/hoff/releases/tag/v0.30.0
Wrong: https://github.com/channable/hoff/releases/tags/v0.30.0