### PR TITLE
Fix GitHub markdown parsing on first line of feedback comment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,20 @@
 # Changelog
 
+## Unreleased
+
+ * Fixed a regression from 0.31.3 where links in Hoff's messages are not
+   properly displayed on GitHub.
+
 ## 0.31.3
 
 Released 2021-06-07.
 
  * Changed the build system to use plain Cabal instead of Stack. Check the
    readme for more details.
+ * Prevent Hoff from replying to its own feedback messages. This is relevant
+   when the command prefix is set to the bot's username, and the merge command
+   was posted from that same account. Before this change Hoff would reply with a
+   harmless but annoying parser error message.
 
 ## 0.31.2
 

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -505,9 +505,13 @@ isSuccess _ = False
 type Parser = Parsec Void Text
 
 -- | A comment that can be added to a message that will cause it to not parse
--- the message for merge commands. This is parsed in 'shouldIgnoreComment'.
+-- the message for merge commands. This is parsed in 'shouldIgnoreComment'. Note
+-- the trailing line feed here. GitHub's markdown parser won't parse markdown if
+-- it's on the same line as an HTML comment:
+--
+-- https://github.com/channable/hoff/issues/227
 hoffIgnoreComment :: Text
-hoffIgnoreComment = "<!-- Hoff: ignore -->"
+hoffIgnoreComment = "<!-- Hoff: ignore -->\n"
 
 -- | Checks if a comment contains 'hoffIgnoreComment', matching case
 -- insensitively and allowing variations in whitespace. This is used to prevent

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -503,7 +503,7 @@ main = hspec $ do
     -- parsing failure. Before the parser was rewritten this was valid as long
     -- as the message also contained a valid command.
     it "rejects command at end of other comments on the same line if tagged multiple times" $
-      expectSimpleParseFailure "@bot looks good to me, @bot merge" "<!-- Hoff: ignore -->Unknown or invalid command found:\n\n    comment:1:6:\n      |\n    1 | @bot looks good to me, @bot merge\n      |      ^^^^^\n    unexpected \"looks\"\n    expecting \"merge\", \"retry\", or white space\n"
+      expectSimpleParseFailure "@bot looks good to me, @bot merge" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:6:\n      |\n    1 | @bot looks good to me, @bot merge\n      |      ^^^^^\n    unexpected \"looks\"\n    expecting \"merge\", \"retry\", or white space\n"
 
     it "accepts command before comments" $ do
       let state  = singlePullRequestState (PullRequestId 1) (Branch "p") masterBranch (Sha "6412ef5") "sacha"
@@ -552,11 +552,11 @@ main = hspec $ do
       actions0 `shouldBe` []
       actions1 `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") [] False
         , ALeaveComment (PullRequestId 1)
-            "<!-- Hoff: ignore -->Failed to rebase, please rebase manually using\n\n\
+            "<!-- Hoff: ignore -->\nFailed to rebase, please rebase manually using\n\n\
             \    git fetch && git rebase --interactive --autosquash origin/master p"
         ]
 
@@ -581,26 +581,26 @@ main = hspec $ do
         (finalState, actions) = runActionCustom results $ handleEventsTest events state
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as b71, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as b71, waiting for CI …"
 
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "dec")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as c82 behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as c82 behind 1 other PR, waiting for CI …"
 
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Pull request approved for merge and deploy to staging by @deckard, waiting for rebase behind 2 pull requests."
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nPull request approved for merge and deploy to staging by @deckard, waiting for rebase behind 2 pull requests."
         , ATryIntegrate "Merge #3: Another PR\n\nApproved-by: deckard\nAuto-deploy: true\nDeploy-Environment: staging\n"
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "f16")
                         [PullRequestId 1, PullRequestId 2]
                         True
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as d93 behind 2 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as d93 behind 2 other PRs, waiting for CI …"
         ]
       classifiedPullRequestIds finalState `shouldBe` ClassifiedPullRequestIds
         { building = [PullRequestId 1, PullRequestId 2, PullRequestId 3]
@@ -627,20 +627,20 @@ main = hspec $ do
         (state', actions) = run $ handleEventsTest events state
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as b71, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #3: Another PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "f16") [PullRequestId 1] False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as b72 behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as b72 behind 1 other PR, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, waiting for rebase behind 2 pull requests."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, waiting for rebase behind 2 pull requests."
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "dec") [PullRequestId 1, PullRequestId 3] False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as b73 behind 2 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as b73 behind 2 other PRs, waiting for CI …"
         ]
       Project.pullRequestApprovalIndex state' `shouldBe` 3
       Project.pullRequests state' `shouldBe`
@@ -696,22 +696,22 @@ main = hspec $ do
         actionsPermuted = snd $ run $ handleEventsTest eventsPermuted state
       actionsPermuted `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "dec") [] False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as b71, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as b71, waiting for CI …"
 
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") [PullRequestId 2] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Speculatively rebased as b72 behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nSpeculatively rebased as b72 behind 1 other PR, waiting for CI …"
 
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, waiting for rebase behind 2 pull requests."
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, waiting for rebase behind 2 pull requests."
         , ATryIntegrate "Merge #3: Another PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "f16") [PullRequestId 2, PullRequestId 1] False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as b73 behind 2 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as b73 behind 2 other PRs, waiting for CI …"
         ]
 
     it "abandons integration when a pull request is closed" $ do
@@ -738,20 +738,20 @@ main = hspec $ do
       Project.unfailedIntegratedPullRequests state' `shouldBe` [PullRequestId 2]
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a38") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as b71, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as b71, waiting for CI …"
         , AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, waiting for rebase behind one pull request."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "dec") [PullRequestId 1] False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as b72 behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as b72 behind 1 other PR, waiting for CI …"
         , ALeaveComment (PullRequestId 1) "Abandoning this pull request because it was closed."
         , ACleanupTestBranch (PullRequestId 1)
         , ATryIntegrate "Merge #2: Some PR\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "dec") [] False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as b73, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as b73, waiting for CI …"
         ]
       classifiedPullRequestIds state' `shouldBe` ClassifiedPullRequestIds
         { building = [PullRequestId 2]
@@ -862,10 +862,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and deploy to staging by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and deploy to staging by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\nDeploy-Environment: staging\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -883,10 +883,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and deploy to production by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and deploy to production by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\nDeploy-Environment: production\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -905,7 +905,7 @@ main = hspec $ do
         results = defaultResults { resultIntegrate = [Right (Sha "def2345")] }
         (_, actions) = runActionCustomConfig (testProjectConfig{Config.deployEnvironments = Just []}) results $ handleEventTest event state
 
-      actions `shouldBe` [ALeaveComment prId "<!-- Hoff: ignore -->Unknown or invalid command found:\n\n    comment:1:22:\n      |\n    1 | @bot merge and deploy\n      |                      ^\n    No deployment environments have been configured.\n"]
+      actions `shouldBe` [ALeaveComment prId "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:22:\n      |\n    1 | @bot merge and deploy\n      |                      ^\n    No deployment environments have been configured.\n"]
 
     it "recognizes 'merge and deploy on Friday' commands as the proper ApprovedFor value" $ do
       let
@@ -919,10 +919,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and deploy to staging by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and deploy to staging by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\nDeploy-Environment: staging\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -940,10 +940,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and tag by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and tag by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -961,10 +961,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and tag by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and tag by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -982,10 +982,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and tag by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and tag by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1003,10 +1003,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and tag by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and tag by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1024,10 +1024,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1045,17 +1045,17 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
         (\pr -> Project.approval pr == Just (Approval (Username "deckard") Project.Merge 0 Nothing))
 
     it "notifies when command not recognized"
-      $ expectSimpleParseFailure  "@bot mergre" "<!-- Hoff: ignore -->Unknown or invalid command found:\n\n    comment:1:6:\n      |\n    1 | @bot mergre\n      |      ^^^^^\n    unexpected \"mergr\"\n    expecting \"merge\", \"retry\", or white space\n"
+      $ expectSimpleParseFailure  "@bot mergre" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:6:\n      |\n    1 | @bot mergre\n      |      ^^^^^\n    unexpected \"mergr\"\n    expecting \"merge\", \"retry\", or white space\n"
 
     it "allow 'merge' on Friday for exempted users" $ do
       let
@@ -1069,10 +1069,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "bot"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge by @bot, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge by @bot, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: bot\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
     it "doesn't allow 'merge and tag' command on Friday" $ do
@@ -1134,7 +1134,7 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate
             { mergeMessage = "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
             , integrationCandidate = (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234")
@@ -1142,7 +1142,7 @@ main = hspec $ do
             , alwaysAddMergeCommit = False
             }
         , ALeaveComment (PullRequestId 1)
-            "<!-- Hoff: ignore -->Empty rebase.  Have the changes already been merged into the target branch?  Aborting."
+            "<!-- Hoff: ignore -->\nEmpty rebase.  Have the changes already been merged into the target branch?  Aborting."
         ]
 
     it "rejects 'merge' commands to a branch other than master" $ do
@@ -1156,7 +1156,7 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Merge rejected: the base branch of this pull request must be set to master. It is currently set to m."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nMerge rejected: the base branch of this pull request must be set to master. It is currently set to m."
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1177,12 +1177,12 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer (Username "deckard")
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Merge rejected: the base branch of this pull request must be set to master. It is currently set to m."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nMerge rejected: the base branch of this pull request must be set to master. It is currently set to m."
         , AIsReviewer (Username "deckard")
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \8230"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \8230"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1204,10 +1204,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer (Username "deckard")
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \8230"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \8230"
         , ALeaveComment (PullRequestId 1) "Stopping integration because the PR changed after approval."
         , ACleanupTestBranch (PullRequestId 1)
         ]
@@ -1231,10 +1231,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer (Username "deckard")
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \8230"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \8230"
         , ALeaveComment (PullRequestId 1) "Stopping integration because the PR changed after approval."
         , ACleanupTestBranch (PullRequestId 1)
         ]
@@ -1245,7 +1245,7 @@ main = hspec $ do
     -- Previous versions of Hoff would still match the @merge and deploy@ part
     -- and deploy to the default environment instead
     it "rejects 'merge and deploy to prohno' with an error message"
-      $ expectSimpleParseFailure  "@bot merge and deploy to prohno" "<!-- Hoff: ignore -->Unknown or invalid command found:\n\n    comment:1:26:\n      |\n    1 | @bot merge and deploy to prohno\n      |                          ^^^^^^\n    unexpected \"prohno\"\n    expecting \"production\", \"staging\", or white space\n"
+      $ expectSimpleParseFailure  "@bot merge and deploy to prohno" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:26:\n      |\n    1 | @bot merge and deploy to prohno\n      |                          ^^^^^^\n    unexpected \"prohno\"\n    expecting \"production\", \"staging\", or white space\n"
 
     it "allows merge commands followed by a period at the end of a sentence" $ do
       let
@@ -1259,10 +1259,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and deploy to staging by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and deploy to staging by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\nDeploy-Environment: staging\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1282,10 +1282,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and deploy to staging by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and deploy to staging by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\nDeploy-Environment: staging\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1297,14 +1297,14 @@ main = hspec $ do
     -- commands are added take freeform strings as their arguments (e.g. tag
     -- messages).
     it "rejects merge commands when it is followed by another sentence before a line break"
-      $ expectSimpleParseFailure  "@bot merge and deploy. Done!" "<!-- Hoff: ignore -->Unknown or invalid command found:\n\n    comment:1:24:\n      |\n    1 | @bot merge and deploy. Done!\n      |                        ^\n    Merge commands may not be followed by anything other than a punctuation character ('.', ',', '!', '?', ':', ';').\n"
+      $ expectSimpleParseFailure  "@bot merge and deploy. Done!" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:24:\n      |\n    1 | @bot merge and deploy. Done!\n      |                        ^\n    Merge commands may not be followed by anything other than a punctuation character ('.', ',', '!', '?', ':', ';').\n"
 
     -- This is already implicitly checked in 'expectSimpleParseFailure', you can
     -- never be too sure
     it "ignores comments containing a special 'Hoff: ignore' HTML comment" $
       let prId = PullRequestId 1
           state = singlePullRequestState prId (Branch "p") masterBranch (Sha "abc1234") "tyrell"
-          event = [CommentAdded prId "bot"  "<!-- Hoff: ignore -->Unknown or invalid command found:\n\n    comment:1:24:\n      |\n    1 | @bot merge and deploy!\n      |                        ^\n    Merge commands may not be followed by anything other than a punctuation character ('.', ',', '!', '?', ':', ';').\n"]
+          event = [CommentAdded prId "bot"  "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:24:\n      |\n    1 | @bot merge and deploy!\n      |                        ^\n    Merge commands may not be followed by anything other than a punctuation character ('.', ',', '!', '?', ':', ';').\n"]
           (_, actions) = runActionCustom defaultResults $ handleEventsTest event state
        in actions `shouldBe` []
 
@@ -1316,16 +1316,16 @@ main = hspec $ do
           state = singlePullRequestState prId (Branch "p") masterBranch (Sha "abc1234") "tyrell"
           results = defaultResults { resultIntegrate = [Right (Sha "def2345")] }
 
-          approvalMessage =  "<!-- Hoff: ignore -->Pull request approved for merge by @bot, rebasing now."
+          approvalMessage =  "<!-- Hoff: ignore -->\nPull request approved for merge by @bot, rebasing now."
           event =
             -- This merge approval is posted by the bot iself
             [ CommentAdded prId "bot" "@bot merge"
               -- The feedback message then tags the bot, but the special ignore
               -- comment will cause it to ignore the message
             , CommentAdded prId "bot" approvalMessage
-            , CommentAdded prId "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+            , CommentAdded prId "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
             , BuildStatusChanged (Sha "def2345") "default" (Project.BuildStarted "example.com/1b2")
-            , CommentAdded prId "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1b2) started."
+            , CommentAdded prId "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1b2) started."
             , BuildStatusChanged (Sha "def2345") "default" Project.BuildSucceeded
             ]
           (_, actions) = runActionCustom results $ handleEventsTest event state
@@ -1333,8 +1333,8 @@ main = hspec $ do
             [ AIsReviewer (Username "bot")
             , ALeaveComment prId approvalMessage
             , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: bot\nAuto-deploy: false\n" (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
-            , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \8230"
-            , ALeaveComment prId "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1b2) started."
+            , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \8230"
+            , ALeaveComment prId "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1b2) started."
             , ATryPromote (Branch "p") (Sha "def2345")
             , ACleanupTestBranch prId
             ]
@@ -1354,10 +1354,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and deploy to staging by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and deploy to staging by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\nDeploy-Environment: staging\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1375,10 +1375,10 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment prId "<!-- Hoff: ignore -->Pull request approved for merge and deploy to staging by @deckard, rebasing now."
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and deploy to staging by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: true\nDeploy-Environment: staging\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
-        , ALeaveComment prId "<!-- Hoff: ignore -->Rebased as def2345, waiting for CI \x2026"
+        , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
       fromJust (Project.lookupPullRequest prId state') `shouldSatisfy`
@@ -1402,7 +1402,7 @@ main = hspec $ do
       actions `shouldBe`
         [ ATryIntegrate "Merge #1: Untitled\n\nApproved-by: fred\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "f34") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 38c, waiting for CI \x2026"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 38c, waiting for CI \x2026"
         ]
     it "finds a new candidate with multiple PRs" $ do
       let
@@ -1424,10 +1424,10 @@ main = hspec $ do
       actions `shouldBe`
         [ ATryIntegrate "Merge #2: Another untitled\n\nApproved-by: fred\nAuto-deploy: false\n"
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "g35") [] False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 38c, waiting for CI \x2026"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 38c, waiting for CI \x2026"
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: fred\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "f34") [PullRequestId 2] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Speculatively rebased as 49d behind 1 other PR, waiting for CI \x2026"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nSpeculatively rebased as 49d behind 1 other PR, waiting for CI \x2026"
         ]
 
     it "pushes after a successful build" $ do
@@ -1596,7 +1596,7 @@ main = hspec $ do
         [ ATryPromote (Branch "results/rachael") (Sha "38d")
         , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "f35") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 38e, waiting for CI \x2026"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 38e, waiting for CI \x2026"
         ]
 
     it "restarts the sequence after a rejected push with tag" $ do
@@ -1635,7 +1635,7 @@ main = hspec $ do
         [ ATryPromoteWithTag (Branch "results/rachael") (Sha "38d") (TagName "v2") (TagMessage "v2\n\nchangelog")
         , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "f35") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 38e, waiting for CI \x2026"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 38e, waiting for CI \x2026"
         ]
 
     it "can handle a rebase failure after a failed push" $ do
@@ -1673,18 +1673,18 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a39") [] False
           -- The first rebase succeeds.
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as b71, waiting for CI \x2026"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as b71, waiting for CI \x2026"
           -- The first promotion attempt fails
         , ATryPromote (Branch "n7") (Sha "b71")
           -- The second rebase fails.
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a39") [] False
         , ALeaveComment (PullRequestId 1)
-            "<!-- Hoff: ignore -->Failed to rebase, please rebase manually using\n\n\
+            "<!-- Hoff: ignore -->\nFailed to rebase, please rebase manually using\n\n\
             \    git fetch && git rebase --interactive --autosquash origin/master n7"
         ]
 
@@ -1732,7 +1732,7 @@ main = hspec $ do
         , ACleanupTestBranch (PullRequestId 1)
         , ATryIntegrate "Merge #2: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "f37") [] False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 38e, waiting for CI \x2026"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 38e, waiting for CI \x2026"
         ]
 
     it "reports the build status if a user retries the same commit" $ do
@@ -1768,20 +1768,20 @@ main = hspec $ do
 
       actions `shouldBe`
         [ AIsReviewer "deckard"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Add Nexus 7 experiment\n\nApproved-by: deckard\nAuto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "a39") [] False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as b71, waiting for CI \x2026"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->[CI job :yellow_circle:](https://status.example.com/b71) started."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as b71, waiting for CI \x2026"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](https://status.example.com/b71) started."
         , ALeaveComment (PullRequestId 1)
-            "<!-- Hoff: ignore -->The [build failed :x:](https://example.com/build-status).\n\n\
+            "<!-- Hoff: ignore -->\nThe [build failed :x:](https://example.com/build-status).\n\n\
             \If this is the result of a flaky test, then tag me again with the `retry` command.  \
             \Otherwise, push a new commit and tag me again."
         , AIsReviewer "deckard"
           -- Nothing has changed for the bot because b71 has already failed, so
           -- it doesn't retry, but reports the correct state.
         , ALeaveComment (PullRequestId 1)
-            "<!-- Hoff: ignore -->The [build failed :x:](https://example.com/build-status).\n\n\
+            "<!-- Hoff: ignore -->\nThe [build failed :x:](https://example.com/build-status).\n\n\
             \If this is the result of a flaky test, then tag me again with the `retry` command.  \
             \Otherwise, push a new commit and tag me again."
         ]
@@ -2049,8 +2049,8 @@ main = hspec $ do
         results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
         events =
           [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
           , BuildStatusChanged (Sha "1b2") "default" (Project.BuildStarted "example.com/1b2")
           , BuildStatusChanged (Sha "1b2") "default" (Project.BuildStarted "example.com/alt1/1b2")
           , BuildStatusChanged (Sha "1b2") "default" (Project.BuildStarted "example.com/alt2/1b2")
@@ -2058,15 +2058,15 @@ main = hspec $ do
         actions = snd $ runActionCustom results $ handleEventsTest events state
       actions `shouldBe`
         [ AIsReviewer (Username "deckard")
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                         []
                         False
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1b2) started."
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1b2) started."
         ]
 
     it "build failures cannot be superseded by other statuses" $ do
@@ -2078,10 +2078,10 @@ main = hspec $ do
         results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
         events =
           [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
           , BuildStatusChanged (Sha "1b2") "default" (Project.BuildStarted "example.com/1b2")
-          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1b2) started."
+          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1b2) started."
           , BuildStatusChanged (Sha "1b2") "default" (Project.BuildFailed (Just "example.com/1b2"))
           , BuildStatusChanged (Sha "1b2") "default" Project.BuildPending -- ignored
           , BuildStatusChanged (Sha "1b2") "default" (Project.BuildStarted "example.com/1b2") -- ignored
@@ -2091,16 +2091,16 @@ main = hspec $ do
         actions = snd $ runActionCustom results $ handleEventsTest events state
       actions `shouldBe`
         [ AIsReviewer (Username "deckard")
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                         []
                         False
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1b2) started."
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->The [build failed :x:](example.com/1b2).\n\n\
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1b2) started."
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nThe [build failed :x:](example.com/1b2).\n\n\
                                            \If this is the result of a flaky test, \
                                            \then tag me again with the `retry` command.  \
                                            \Otherwise, push a new commit and tag me again."
@@ -2115,10 +2115,10 @@ main = hspec $ do
         results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
         events =
           [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+          , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
           , BuildStatusChanged (Sha "1b2") "default" (Project.BuildStarted "example.com/1b2")
-          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1b2) started."
+          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1b2) started."
           , BuildStatusChanged (Sha "1b2") "default" Project.BuildSucceeded
           , BuildStatusChanged (Sha "1b2") "default" Project.BuildPending -- ignored
           , BuildStatusChanged (Sha "1b2") "default" (Project.BuildStarted "example.com/1b2") -- ignored
@@ -2127,15 +2127,15 @@ main = hspec $ do
         (finalState, actions) = runActionCustom results $ handleEventsTest events state
       actions `shouldBe`
         [ AIsReviewer (Username "deckard")
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                         []
                         False
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1b2) started."
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+        , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1b2) started."
         , ATryPromote (Branch "tth") (Sha "1b2")
         , ACleanupTestBranch (PullRequestId 12)
         ]
@@ -2163,13 +2163,13 @@ main = hspec $ do
           events =
             [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
             , CommentAdded (PullRequestId 13) "deckard" "@bot merge"
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-            , CommentAdded (PullRequestId 13) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-            , CommentAdded (PullRequestId 13) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+            , CommentAdded (PullRequestId 13) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+            , CommentAdded (PullRequestId 13) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
             , BuildStatusChanged (Sha "1b2") "first" (Project.BuildStarted "example.com/1b2")
             , BuildStatusChanged (Sha "1b2") "required" (Project.BuildStarted "example.com/required/1b2")
-            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
             , BuildStatusChanged (Sha "1b2") "first" (Project.BuildFailed Nothing)
             , BuildStatusChanged (Sha "1b2") "required" Project.BuildSucceeded
             , BuildStatusChanged (Sha "1b3") "required" Project.BuildSucceeded
@@ -2177,17 +2177,17 @@ main = hspec $ do
           (finalState, actions) = runActionCustom results $ handleEventsTest events state
         actions `shouldBe`
           [ AIsReviewer (Username "deckard")
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
           , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                           \Approved-by: deckard\n\
                           \Auto-deploy: false\n"
                           (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                           []
                           False
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
           , AIsReviewer (Username "deckard")
           , ALeaveComment (PullRequestId 13)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
           , ATryIntegrate "Merge #13: Thirteenth PR\n\n\
                           \Approved-by: deckard\n\
@@ -2195,8 +2195,8 @@ main = hspec $ do
                           (PullRequestId 13,Branch "refs/pull/13/head",Sha "13a")
                           [PullRequestId 12]
                           False
-          , ALeaveComment (PullRequestId 13) "<!-- Hoff: ignore -->Speculatively rebased as 1b3 behind 1 other PR, waiting for CI …"
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+          , ALeaveComment (PullRequestId 13) "<!-- Hoff: ignore -->\nSpeculatively rebased as 1b3 behind 1 other PR, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
           , ATryPromote (Branch "tth") (Sha "1b2")
           , ACleanupTestBranch (PullRequestId 12)
           , ATryPromote (Branch "ttg") (Sha "1b3")
@@ -2222,26 +2222,26 @@ main = hspec $ do
           results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
           events =
             [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
             , BuildStatusChanged (Sha "1b2") "first" (Project.BuildStarted "example.com/1b2")
             , BuildStatusChanged (Sha "1b2") "required" (Project.BuildStarted "example.com/required/1b2")
-            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
             , BuildStatusChanged (Sha "1b2") "first" (Project.BuildFailed Nothing)
             , BuildStatusChanged (Sha "1b2") "required" Project.BuildSucceeded
             ]
           (finalState, actions) = runActionCustom results $ handleEventsTest events state
         actions `shouldBe`
           [ AIsReviewer (Username "deckard")
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
           , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                           \Approved-by: deckard\n\
                           \Auto-deploy: false\n"
                           (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                           []
                           False
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
           , ATryPromote (Branch "tth") (Sha "1b2")
           , ACleanupTestBranch (PullRequestId 12)
           ]
@@ -2265,27 +2265,27 @@ main = hspec $ do
           results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
           events =
             [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
             , BuildStatusChanged (Sha "1b2") "first" (Project.BuildStarted "example.com/1b2")
             , BuildStatusChanged (Sha "1b2") "required" (Project.BuildStarted "example.com/required/1b2")
-            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
             , BuildStatusChanged (Sha "1b2") "first" Project.BuildSucceeded
             , BuildStatusChanged (Sha "1b2") "required" (Project.BuildFailed Nothing)
             ]
           (finalState, actions) = runActionCustom results $ handleEventsTest events state
         actions `shouldBe`
           [ AIsReviewer (Username "deckard")
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
           , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                           \Approved-by: deckard\n\
                           \Auto-deploy: false\n"
                           (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                           []
                           False
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                             \If this is the result of a flaky test, \
                                             \then tag me again with the `retry` command.  \
                                             \Otherwise, push a new commit and tag me again."
@@ -2309,25 +2309,25 @@ main = hspec $ do
           results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
           events =
             [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
             , BuildStatusChanged (Sha "1b2") "first" (Project.BuildStarted "example.com/1b2")
             , BuildStatusChanged (Sha "1b2") "required" (Project.BuildStarted "example.com/required/1b2")
-            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
             , BuildStatusChanged (Sha "1b2") "first" Project.BuildSucceeded
             ]
           (finalState, actions) = runActionCustom results $ handleEventsTest events state
         actions `shouldBe`
           [ AIsReviewer (Username "deckard")
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
           , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                           \Approved-by: deckard\n\
                           \Auto-deploy: false\n"
                           (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                           []
                           False
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
           ]
         -- test caveat, in reality, when Promote works,
         -- the PR is removed from the building list.
@@ -2349,26 +2349,26 @@ main = hspec $ do
           results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
           events =
             [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
             , BuildStatusChanged (Sha "1b2") "first" (Project.BuildStarted "example.com/1b2")
             , BuildStatusChanged (Sha "1b2") "required" (Project.BuildStarted "example.com/required/1b2")
-            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
             , BuildStatusChanged (Sha "1b2") "first" Project.BuildSucceeded
             , BuildStatusChanged (Sha "1b2") "required" Project.BuildSucceeded
             ]
           (finalState, actions) = runActionCustom results $ handleEventsTest events state
         actions `shouldBe`
           [ AIsReviewer (Username "deckard")
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
           , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                           \Approved-by: deckard\n\
                           \Auto-deploy: false\n"
                           (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                           []
                           False
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
           , ATryPromote (Branch "tth") (Sha "1b2")
           , ACleanupTestBranch (PullRequestId 12)
           ]
@@ -2392,26 +2392,26 @@ main = hspec $ do
           results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
           events =
             [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
             , BuildStatusChanged (Sha "1b2") "required" (Project.BuildStarted "example.com/required/1b2")
             , BuildStatusChanged (Sha "1b2") "mandatory" (Project.BuildStarted "example.com/mandatory/1b2")
-            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
             , BuildStatusChanged (Sha "1b2") "required" Project.BuildSucceeded
             , BuildStatusChanged (Sha "1b2") "mandatory" Project.BuildSucceeded
             ]
           (finalState, actions) = runActionCustom results $ handleEventsTest events state
         actions `shouldBe`
           [ AIsReviewer (Username "deckard")
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
           , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                           \Approved-by: deckard\n\
                           \Auto-deploy: false\n"
                           (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                           []
                           False
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
           , ATryPromote (Branch "tth") (Sha "1b2")
           , ACleanupTestBranch (PullRequestId 12)
           ]
@@ -2435,25 +2435,25 @@ main = hspec $ do
           results = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
           events =
             [ CommentAdded (PullRequestId 12) "deckard" "@bot merge"
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+            , CommentAdded (PullRequestId 12) "bot" "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
             , BuildStatusChanged (Sha "1b2") "required" (Project.BuildStarted "example.com/required/1b2")
             , BuildStatusChanged (Sha "1b2") "mandatory" (Project.BuildStarted "example.com/mandatory/1b2")
-            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
+            , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
             ]
           commonAssertions actions finalState = do
             actions `shouldBe`
               [ AIsReviewer (Username "deckard")
-              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
               , ATryIntegrate "Merge #12: Twelfth PR\n\n\
                               \Approved-by: deckard\n\
                               \Auto-deploy: false\n"
                               (PullRequestId 12,Branch "refs/pull/12/head",Sha "12a")
                               []
                               False
-              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI …"
-              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/required/1b2) started."
-              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI …"
+              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/required/1b2) started."
+              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                                 \If this is the result of a flaky test, \
                                                 \then tag me again with the `retry` command.  \
                                                 \Otherwise, push a new commit and tag me again."
@@ -2501,11 +2501,11 @@ main = hspec $ do
 
           commonActions =
             [ AIsReviewer (Username "deckard")
-            , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+            , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
             , ATryIntegrate "Merge #12: Twelfth PR\n\nApproved-by: deckard\nAuto-deploy: false\n" (PullRequestId 12, Branch "refs/pull/12/head", Sha "12a") [] False
-            , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI \8230"
-            , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](url) started."
-            , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->The [build failed :x:](url).\n\nIf this is the result of a flaky test, then tag me again with the `retry` command.  Otherwise, push a new commit and tag me again."
+            , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI \8230"
+            , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](url) started."
+            , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nThe [build failed :x:](url).\n\nIf this is the result of a flaky test, then tag me again with the `retry` command.  Otherwise, push a new commit and tag me again."
             ]
 
           commonResults = defaultResults {resultIntegrate = [Right (Sha "1b2")]}
@@ -2544,10 +2544,10 @@ main = hspec $ do
           ]
           [ AIsReviewer (Username "deckard")
           , ACleanupTestBranch (PullRequestId 12)
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard (retried by @deckard), rebasing now."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard (retried by @deckard), rebasing now."
           , ATryIntegrate "Merge #12: Twelfth PR\n\nApproved-by: deckard\nAuto-deploy: false\n"  (PullRequestId 12, Branch "refs/pull/12/head", Sha "12a") [] False
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 00f, waiting for CI …"
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](url2) started."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 00f, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](url2) started."
           , ATryPromote (Branch "tth") (Sha "00f")
           , ACleanupTestBranch (PullRequestId 12)
           ]
@@ -2570,10 +2570,10 @@ main = hspec $ do
           ]
           [ AIsReviewer (Username "deckard")
           , ACleanupTestBranch (PullRequestId 12)
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard (retried by @deckard), rebasing now."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard (retried by @deckard), rebasing now."
           , ATryIntegrate "Merge #12: Twelfth PR\n\nApproved-by: deckard\nAuto-deploy: false\n"  (PullRequestId 12, Branch "refs/pull/12/head", Sha "12a") [] False
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 00f, waiting for CI …"
-          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](url2) started."
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 00f, waiting for CI …"
+          , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](url2) started."
           , ATryPromote (Branch "tth") (Sha "00f")
           , ACleanupTestBranch (PullRequestId 12)
           ]
@@ -2611,10 +2611,10 @@ main = hspec $ do
               ]
             actions' =
               [ AIsReviewer (Username "deckard")
-              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
               , ATryIntegrate "Merge #12: Twelfth PR\n\nApproved-by: deckard\nAuto-deploy: false\n" (PullRequestId 12, Branch "refs/pull/12/head", Sha "12a") [] False
-              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->Rebased as 1b2, waiting for CI \8230"
-              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->[CI job :yellow_circle:](url) started."
+              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\nRebased as 1b2, waiting for CI \8230"
+              , ALeaveComment (PullRequestId 12) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](url) started."
               , AIsReviewer (Username "deckard")
               , ALeaveComment (PullRequestId 12) "Only approved PRs with failed builds can be retried.."
               ]
@@ -2658,29 +2658,29 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 19)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #19: Nineteenth PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 19, Branch "refs/pull/19/head", Sha "19a")
                         []
                         False
-        , ALeaveComment (PullRequestId 19) "<!-- Hoff: ignore -->Rebased as a19, waiting for CI …"
-        , ALeaveComment (PullRequestId 19) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 19) "<!-- Hoff: ignore -->\nRebased as a19, waiting for CI …"
+        , ALeaveComment (PullRequestId 19) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 36)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #36: Thirty-sixth PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 36, Branch "refs/pull/36/head", Sha "36b")
                         []
                         False
-        , ALeaveComment (PullRequestId 36) "<!-- Hoff: ignore -->Rebased as b36, waiting for CI …"
-        , ALeaveComment (PullRequestId 36) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 36) "<!-- Hoff: ignore -->\nRebased as b36, waiting for CI …"
+        , ALeaveComment (PullRequestId 36) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -2759,17 +2759,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -2777,10 +2777,10 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2bc behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2bc behind 1 other PR, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                         \waiting for rebase behind 2 pull requests."
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
@@ -2788,7 +2788,7 @@ main = hspec $ do
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         [PullRequestId 1, PullRequestId 2]
                         False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as 3cd behind 2 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as 3cd behind 2 other PRs, waiting for CI …"
         , ALeaveComment (PullRequestId 1) "Stopping integration because the PR changed after approval."
         , ACleanupTestBranch (PullRequestId 1)
         , ATryIntegrate "Merge #2: Second PR\n\n\
@@ -2797,14 +2797,14 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         []
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 5bc, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 5bc, waiting for CI …"
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         [PullRequestId 2]
                         False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as 6cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as 6cd behind 1 other PR, waiting for CI …"
         ]
       classifiedPullRequestIds finalState `shouldBe` ClassifiedPullRequestIds
         { building = [PullRequestId 2, PullRequestId 3]
@@ -2833,17 +2833,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -2855,7 +2855,7 @@ main = hspec $ do
         -- , ALeaveComment (PullRequestId 2) "Failed speculative rebase.  Waiting in the queue for a rebase on master."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                         \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
@@ -2863,12 +2863,12 @@ main = hspec $ do
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as 3cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as 3cd behind 1 other PR, waiting for CI …"
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
         -- PR#2 is only notified after PR#1 passes or fails
         , ALeaveComment (PullRequestId 2)
-                        "<!-- Hoff: ignore -->Failed to rebase, please rebase manually using\n\n\
+                        "<!-- Hoff: ignore -->\nFailed to rebase, please rebase manually using\n\n\
                         \    git fetch && git rebase --interactive --autosquash origin/master snd"
         ]
       classifiedPullRequestIds finalState `shouldBe` ClassifiedPullRequestIds
@@ -2900,17 +2900,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -2922,7 +2922,7 @@ main = hspec $ do
         -- , ALeaveComment (PullRequestId 2) "Failed speculative rebase.  Waiting in the queue for a rebase on master."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                         \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
@@ -2930,8 +2930,8 @@ main = hspec $ do
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as 3cd behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->The [build failed :x:](ci.example.com/1ab).\n\n\
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as 3cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nThe [build failed :x:](ci.example.com/1ab).\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -2942,14 +2942,14 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         []
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 5bc, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 5bc, waiting for CI …"
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         [PullRequestId 2]
                         False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as 6cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as 6cd behind 1 other PR, waiting for CI …"
         ]
       classifiedPullRequestIds finalState `shouldBe` ClassifiedPullRequestIds
         { building = [PullRequestId 2, PullRequestId 3]
@@ -2975,17 +2975,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -2994,7 +2994,7 @@ main = hspec $ do
                         [PullRequestId 1]
                         False
         , ALeaveComment (PullRequestId 2)
-                        "<!-- Hoff: ignore -->Pull request cannot be integrated\
+                        "<!-- Hoff: ignore -->\nPull request cannot be integrated\
                         \ as it contains fixup commits that\
                         \ do not belong to any other commits."
         ]
@@ -3028,17 +3028,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3047,12 +3047,12 @@ main = hspec $ do
                         [PullRequestId 1]
                         False
         , ALeaveComment (PullRequestId 2)
-                        "<!-- Hoff: ignore -->Pull request cannot be integrated\
+                        "<!-- Hoff: ignore -->\nPull request cannot be integrated\
                         \ as it contains fixup commits that\
                         \ do not belong to any other commits."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
@@ -3060,12 +3060,12 @@ main = hspec $ do
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as 3cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as 3cd behind 1 other PR, waiting for CI …"
         -- upon commit changed on PR#2, there is no reason to reintegrate PR#3
         -- PR#2 is moved to the end of the train after a new merge command
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind 2 pull requests."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3073,7 +3073,7 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "c2d")
                         [PullRequestId 1, PullRequestId 3]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2bc behind 2 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2bc behind 2 other PRs, waiting for CI …"
         ]
       classifiedPullRequestIds finalState `shouldBe` ClassifiedPullRequestIds
         { building = [PullRequestId 1, PullRequestId 3, PullRequestId 2]
@@ -3101,17 +3101,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3119,7 +3119,7 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
         , ATryPromote (Branch "snd") (Sha "2cd")
@@ -3146,17 +3146,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3164,7 +3164,7 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
         , ATryPromote (Branch "snd") (Sha "2cd")
@@ -3191,17 +3191,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3209,8 +3209,8 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -3221,8 +3221,8 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         []
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 22e, waiting for CI …"
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 22e, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -3255,17 +3255,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3273,9 +3273,9 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculative build failed :x:.  I will automatically retry after getting build results for #1."
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculative build failed :x:.  I will automatically retry after getting build results for #1."
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -3286,8 +3286,8 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         []
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 22e, waiting for CI …"
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 22e, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -3318,17 +3318,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3336,10 +3336,10 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -3364,17 +3364,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3382,11 +3382,11 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculative build failed :x:.  I will automatically retry after getting build results for #1."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculative build failed :x:.  I will automatically retry after getting build results for #1."
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -3413,17 +3413,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3431,8 +3431,8 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -3442,7 +3442,7 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         []
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 22e, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 22e, waiting for CI …"
         , ATryPromote (Branch "snd") (Sha "22e")
         , ACleanupTestBranch (PullRequestId 2)
         ]
@@ -3468,17 +3468,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3486,8 +3486,8 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->The build failed :x:.\n\n\
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nThe build failed :x:.\n\n\
                                           \If this is the result of a flaky test, \
                                           \then tag me again with the `retry` command.  \
                                           \Otherwise, push a new commit and tag me again."
@@ -3497,7 +3497,7 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         []
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 22e, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 22e, waiting for CI …"
         , ATryPromote (Branch "snd") (Sha "22e")
         , ACleanupTestBranch (PullRequestId 2)
         ]
@@ -3523,17 +3523,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3541,7 +3541,7 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2cd behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2cd behind 1 other PR, waiting for CI …"
         , ALeaveComment (PullRequestId 1) "Abandoning this pull request because it was closed."
         , ACleanupTestBranch (PullRequestId 1)
         , ATryIntegrate "Merge #2: Second PR\n\n\
@@ -3550,7 +3550,7 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         []
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Rebased as 22e, waiting for CI …"
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nRebased as 22e, waiting for CI …"
         , ATryPromote (Branch "snd") (Sha "22e")
         , ACleanupTestBranch (PullRequestId 2)
         ]
@@ -3573,27 +3573,27 @@ main = hspec $ do
           [ BuildStatusChanged (Sha "ab1") "default" (Project.BuildSucceeded) -- PR#1 sha, ignored
           , CommentAdded (PullRequestId 1) "deckard" "@someone Thanks for your review."
           , CommentAdded (PullRequestId 1) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
           , CommentAdded (PullRequestId 2) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->Pull request approved for merge behind 1 PR."
+          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge behind 1 PR."
           , BuildStatusChanged (Sha "ef3") "default" (Project.BuildSucceeded) -- PR#3 sha, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildPending) -- same status, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildStarted "example.com/1ab")
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildStarted "example.com/1ab") -- dup!
-          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1ab) started."
+          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1ab) started."
           , CommentAdded (PullRequestId 3) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 3) "bot" "<!-- Hoff: ignore -->Pull request approved for merge behind 2 PRs."
+          , CommentAdded (PullRequestId 3) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge behind 2 PRs."
           , BuildStatusChanged (Sha "cd2") "default" (Project.BuildSucceeded) -- PR#2 sha, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildSucceeded) -- PR#1
           , PullRequestClosed (PullRequestId 1)
-          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->Rebased as 2bc, waiting for CI …"
+          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->\nRebased as 2bc, waiting for CI …"
           , BuildStatusChanged (Sha "2bc") "default" (Project.BuildStarted "example.com/2bc")
-          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/2bc) started."
+          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/2bc) started."
           , BuildStatusChanged (Sha "36a") "default" (Project.BuildSucceeded) -- arbitrary sha, ignored
           , BuildStatusChanged (Sha "2bc") "default" (Project.BuildSucceeded) -- PR#2
           , PullRequestClosed (PullRequestId 2)
-          , CommentAdded (PullRequestId 3) "bot" "<!-- Hoff: ignore -->Rebased as 3cd, waiting for CI …"
+          , CommentAdded (PullRequestId 3) "bot" "<!-- Hoff: ignore -->\nRebased as 3cd, waiting for CI …"
           , BuildStatusChanged (Sha "3cd") "default" (Project.BuildStarted "example.com/3cd")
           , BuildStatusChanged (Sha "3cd") "default" (Project.BuildSucceeded) -- PR#3
           , PullRequestClosed (PullRequestId 3)
@@ -3607,17 +3607,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3625,11 +3625,11 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2bc behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1ab) started."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2bc behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1ab) started."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                         \waiting for rebase behind 2 pull requests."
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
@@ -3637,13 +3637,13 @@ main = hspec $ do
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         [PullRequestId 1, PullRequestId 2]
                         False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as 3cd behind 2 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as 3cd behind 2 other PRs, waiting for CI …"
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/2bc) started."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/2bc) started."
         , ATryPromote (Branch "snd") (Sha "2bc")
         , ACleanupTestBranch (PullRequestId 2)
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/3cd) started."
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/3cd) started."
         , ATryPromote (Branch "trd") (Sha "3cd")
         , ACleanupTestBranch (PullRequestId 3)
         ]
@@ -3666,28 +3666,28 @@ main = hspec $ do
           [ BuildStatusChanged (Sha "ab9") "default" (Project.BuildSucceeded) -- PR#9 sha, ignored
           , CommentAdded (PullRequestId 9) "deckard" "@someone Thanks for your review."
           , CommentAdded (PullRequestId 9) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 9) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-          , CommentAdded (PullRequestId 9) "bot" "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+          , CommentAdded (PullRequestId 9) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+          , CommentAdded (PullRequestId 9) "bot" "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
           , CommentAdded (PullRequestId 8) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 8) "bot" "<!-- Hoff: ignore -->Pull request approved for merge behind 1 PR."
+          , CommentAdded (PullRequestId 8) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge behind 1 PR."
           , BuildStatusChanged (Sha "ef7") "default" (Project.BuildSucceeded) -- PR#7 sha, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildPending) -- same status, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildStarted "example.com/1ab")
-          , CommentAdded (PullRequestId 9) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1ab) started."
+          , CommentAdded (PullRequestId 9) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1ab) started."
           , CommentAdded (PullRequestId 7) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 7) "bot" "<!-- Hoff: ignore -->Pull request approved for merge behind 2 PRs."
+          , CommentAdded (PullRequestId 7) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge behind 2 PRs."
           , BuildStatusChanged (Sha "cd8") "default" (Project.BuildSucceeded) -- PR#8 sha, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildSucceeded) -- PR#9
           , PullRequestClosed (PullRequestId 9)
-          , CommentAdded (PullRequestId 8) "bot" "<!-- Hoff: ignore -->Rebased as 2bc, waiting for CI …"
+          , CommentAdded (PullRequestId 8) "bot" "<!-- Hoff: ignore -->\nRebased as 2bc, waiting for CI …"
           , BuildStatusChanged (Sha "2bc") "default" (Project.BuildStarted "example.com/2bc")
-          , CommentAdded (PullRequestId 8) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/2bc) started."
+          , CommentAdded (PullRequestId 8) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/2bc) started."
           , BuildStatusChanged (Sha "3cd") "default" (Project.BuildSucceeded) -- testing build passed on PR#7
           , BuildStatusChanged (Sha "36a") "default" (Project.BuildSucceeded) -- arbitrary sha, ignored
           , BuildStatusChanged (Sha "2bc") "default" (Project.BuildFailed (Just "example.com/2bc")) -- PR#8
           , BuildStatusChanged (Sha "2bc") "default" (Project.BuildFailed (Just "example.com/2bc")) -- dup!
-          , CommentAdded (PullRequestId 8) "bot" "<!-- Hoff: ignore -->The [build failed :x:](example.com/2bc)"
-          , CommentAdded (PullRequestId 7) "bot" "<!-- Hoff: ignore -->Rebased as 3cd, waiting for CI …"
+          , CommentAdded (PullRequestId 8) "bot" "<!-- Hoff: ignore -->\nThe [build failed :x:](example.com/2bc)"
+          , CommentAdded (PullRequestId 7) "bot" "<!-- Hoff: ignore -->\nRebased as 3cd, waiting for CI …"
           , BuildStatusChanged (Sha "3ef") "default" (Project.BuildStarted "example.com/3ef")
           , BuildStatusChanged (Sha "3ef") "default" (Project.BuildSucceeded) -- testing build passed on PR#7
           , PullRequestClosed (PullRequestId 7)
@@ -3702,17 +3702,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 9)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #9: Ninth PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 9, Branch "refs/pull/9/head", Sha "ab9")
                         []
                         False
-        , ALeaveComment (PullRequestId 9) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 9) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 8)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #8: Eighth PR\n\n\
                         \Approved-by: deckard\n\
@@ -3720,11 +3720,11 @@ main = hspec $ do
                         (PullRequestId 8, Branch "refs/pull/8/head", Sha "cd8")
                         [PullRequestId 9]
                         False
-        , ALeaveComment (PullRequestId 8) "<!-- Hoff: ignore -->Speculatively rebased as 2bc behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 9) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1ab) started."
+        , ALeaveComment (PullRequestId 8) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2bc behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 9) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1ab) started."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 7)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                         \waiting for rebase behind 2 pull requests."
         , ATryIntegrate "Merge #7: Seventh PR\n\n\
                         \Approved-by: deckard\n\
@@ -3732,12 +3732,12 @@ main = hspec $ do
                         (PullRequestId 7, Branch "refs/pull/7/head", Sha "ef7")
                         [PullRequestId 9, PullRequestId 8]
                         False
-        , ALeaveComment (PullRequestId 7) "<!-- Hoff: ignore -->Speculatively rebased as 3cd behind 2 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 7) "<!-- Hoff: ignore -->\nSpeculatively rebased as 3cd behind 2 other PRs, waiting for CI …"
         , ATryPromote (Branch "nth") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 9)
-        , ALeaveComment (PullRequestId 8) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/2bc) started."
+        , ALeaveComment (PullRequestId 8) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/2bc) started."
         , ALeaveComment (PullRequestId 8)
-                        "<!-- Hoff: ignore -->The [build failed :x:](example.com/2bc).\n\n\
+                        "<!-- Hoff: ignore -->\nThe [build failed :x:](example.com/2bc).\n\n\
                         \If this is the result of a flaky test, \
                         \then tag me again with the `retry` command.  \
                         \Otherwise, push a new commit and tag me again."
@@ -3748,8 +3748,8 @@ main = hspec $ do
                         (PullRequestId 7, Branch "refs/pull/7/head", Sha "ef7")
                         []
                         False
-        , ALeaveComment (PullRequestId 7) "<!-- Hoff: ignore -->Rebased as 3ef, waiting for CI …"
-        , ALeaveComment (PullRequestId 7) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/3ef) started."
+        , ALeaveComment (PullRequestId 7) "<!-- Hoff: ignore -->\nRebased as 3ef, waiting for CI …"
+        , ALeaveComment (PullRequestId 7) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/3ef) started."
         , ATryPromote (Branch "sth") (Sha "3ef")
         , ACleanupTestBranch (PullRequestId 7)
         ]
@@ -3773,29 +3773,29 @@ main = hspec $ do
           [ BuildStatusChanged (Sha "ab1") "default" (Project.BuildSucceeded) -- PR#1 sha, ignored
           , CommentAdded (PullRequestId 1) "deckard" "@someone Thanks for your review."
           , CommentAdded (PullRequestId 1) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->Pull request approved for merge, rebasing now."
-          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge, rebasing now."
+          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
           , CommentAdded (PullRequestId 2) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->Pull request approved for merge behind 1 PR."
+          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge behind 1 PR."
           , BuildStatusChanged (Sha "ef3") "default" (Project.BuildSucceeded) -- PR#3 sha, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildPending) -- same status, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildStarted "example.com/1ab")
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildStarted "example.com/1ab") -- dup!
-          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1ab) started."
+          , CommentAdded (PullRequestId 1) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1ab) started."
           , CommentAdded (PullRequestId 3) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 3) "bot" "<!-- Hoff: ignore -->Pull request approved for merge behind 2 PRs."
+          , CommentAdded (PullRequestId 3) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge behind 2 PRs."
           , CommentAdded (PullRequestId 4) "deckard" "@bot merge"
-          , CommentAdded (PullRequestId 4) "bot" "<!-- Hoff: ignore -->Pull request approved for merge behind 3 PRs."
+          , CommentAdded (PullRequestId 4) "bot" "<!-- Hoff: ignore -->\nPull request approved for merge behind 3 PRs."
           , BuildStatusChanged (Sha "cd2") "default" (Project.BuildSucceeded) -- PR#2 sha, ignored
           , BuildStatusChanged (Sha "1ab") "default" (Project.BuildSucceeded) -- PR#1
           , PullRequestClosed (PullRequestId 1)
-          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->Rebased as 2bc, waiting for CI …"
+          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->\nRebased as 2bc, waiting for CI …"
           , BuildStatusChanged (Sha "2bc") "default" (Project.BuildStarted "example.com/2bc")
-          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/2bc) started."
+          , CommentAdded (PullRequestId 2) "bot" "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/2bc) started."
           , BuildStatusChanged (Sha "36a") "default" (Project.BuildSucceeded) -- arbitrary sha, ignored
           , BuildStatusChanged (Sha "2bc") "default" (Project.BuildSucceeded) -- PR#2
           , PullRequestClosed (PullRequestId 2)
-          , CommentAdded (PullRequestId 3) "bot" "<!-- Hoff: ignore -->Rebased as 3cd, waiting for CI …"
+          , CommentAdded (PullRequestId 3) "bot" "<!-- Hoff: ignore -->\nRebased as 3cd, waiting for CI …"
           , BuildStatusChanged (Sha "3cd") "default" (Project.BuildStarted "example.com/3cd")
           , BuildStatusChanged (Sha "3cd") "default" (Project.BuildSucceeded) -- PR#3
           , PullRequestClosed (PullRequestId 3)
@@ -3813,17 +3813,17 @@ main = hspec $ do
       actions `shouldBe`
         [ AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 1)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, rebasing now."
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: First PR\n\n\
                         \Approved-by: deckard\n\
                         \Auto-deploy: false\n"
                         (PullRequestId 1, Branch "refs/pull/1/head", Sha "ab1")
                         []
                         False
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->Rebased as 1ab, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 1ab, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 2)
-                       "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                       "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                        \waiting for rebase behind one pull request."
         , ATryIntegrate "Merge #2: Second PR\n\n\
                         \Approved-by: deckard\n\
@@ -3831,11 +3831,11 @@ main = hspec $ do
                         (PullRequestId 2, Branch "refs/pull/2/head", Sha "cd2")
                         [PullRequestId 1]
                         False
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->Speculatively rebased as 2bc behind 1 other PR, waiting for CI …"
-        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/1ab) started."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\nSpeculatively rebased as 2bc behind 1 other PR, waiting for CI …"
+        , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/1ab) started."
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 3)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                         \waiting for rebase behind 2 pull requests."
         , ATryIntegrate "Merge #3: Third PR\n\n\
                         \Approved-by: deckard\n\
@@ -3843,10 +3843,10 @@ main = hspec $ do
                         (PullRequestId 3, Branch "refs/pull/3/head", Sha "ef3")
                         [PullRequestId 1, PullRequestId 2]
                         False
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->Speculatively rebased as 3cd behind 2 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\nSpeculatively rebased as 3cd behind 2 other PRs, waiting for CI …"
         , AIsReviewer "deckard"
         , ALeaveComment (PullRequestId 4)
-                        "<!-- Hoff: ignore -->Pull request approved for merge by @deckard, \
+                        "<!-- Hoff: ignore -->\nPull request approved for merge by @deckard, \
                         \waiting for rebase behind 3 pull requests."
         , ATryIntegrate "Merge #4: Fourth PR\n\n\
                         \Approved-by: deckard\n\
@@ -3854,16 +3854,16 @@ main = hspec $ do
                         (PullRequestId 4, Branch "refs/pull/4/head", Sha "fe4")
                         [PullRequestId 1, PullRequestId 2, PullRequestId 3]
                         False
-        , ALeaveComment (PullRequestId 4) "<!-- Hoff: ignore -->Speculatively rebased as 4de behind 3 other PRs, waiting for CI …"
+        , ALeaveComment (PullRequestId 4) "<!-- Hoff: ignore -->\nSpeculatively rebased as 4de behind 3 other PRs, waiting for CI …"
         , ATryPromote (Branch "fst") (Sha "1ab")
         , ACleanupTestBranch (PullRequestId 1)
-        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/2bc) started."
+        , ALeaveComment (PullRequestId 2) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/2bc) started."
         , ATryPromote (Branch "snd") (Sha "2bc")
         , ACleanupTestBranch (PullRequestId 2)
-        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/3cd) started."
+        , ALeaveComment (PullRequestId 3) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/3cd) started."
         , ATryPromote (Branch "trd") (Sha "3cd")
         , ACleanupTestBranch (PullRequestId 3)
-        , ALeaveComment (PullRequestId 4) "<!-- Hoff: ignore -->[CI job :yellow_circle:](example.com/4de) started."
+        , ALeaveComment (PullRequestId 4) "<!-- Hoff: ignore -->\n[CI job :yellow_circle:](example.com/4de) started."
         , ATryPromote (Branch "fth") (Sha "4de")
         , ACleanupTestBranch (PullRequestId 4)
         ]


### PR DESCRIPTION
Fixes #227 by adding a line feed after the `<!-- Hoff: ignore -->` comment. GitHub doesn't parse markdown if it's on the same line as a comment. For example:

<hr>

```
<!-- foo -->[bar](https://google.com)
```

<!-- foo -->[bar](https://google.com)

<hr>

```
<!-- foo --> [bar](https://google.com)
```

<!-- foo --> [bar](https://google.com)

<hr>

```
<!-- foo -->
[bar](https://google.com)
```

<!-- foo -->
[bar](https://google.com)
