### PR TITLE
Check the cabal.project.freeze file using a dry run cabal build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -43,6 +43,10 @@ blocks:
             # contains them.
             - "export LOCALE_ARCHIVE=$(nix-build --no-out-link locale.nix)/lib/locale/locale-archive"
 
+            # This makes sure the version bounds from the `cabal.project.freeze`
+            # file match the versions from nixpkgs
+            - "cabal build --dry-run all"
+
             # Check shell scripts for issues.
             - "shellcheck package/*.sh package/deb-postinst"
 

--- a/hoff.nix
+++ b/hoff.nix
@@ -42,9 +42,7 @@ mkDerivation {
       src = lib.cleanSource ./.;
       filter = gitignoreFilter;
     };
-    # Including the freeze file here will alert us if nixpkgs has been updated
-    # without also updating the freeze file for non-Nix builds
-  in whitelistedSrc // { "cabal.project.freeze" = ../cabal.project.freeze; };
+  in whitelistedSrc;
 
   buildTools = [ makeWrapper ];
 


### PR DESCRIPTION
This is a followup for #229 to use the same freeze file checking used in https://github.com/channable/icepeak/pull/117. Since Hoff won't be used as part of a nixpkgs overlay the current approach won't cause any issues, but it's probalby still better to stay consistent.