### PR TITLE
Subprojects in deploy command

### DIFF
--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -38,7 +38,8 @@ data ProjectConfiguration = ProjectConfiguration
     checkout           :: FilePath,                  -- The path to a local checkout of the repository.
     stateFile          :: FilePath,                  -- The file where project state is stored.
     checks             :: Maybe ChecksConfiguration, -- Optional configuration related to checks for the project.
-    deployEnvironments :: Maybe [Text]               -- The environments which the `deploy to <environment>` command should be enabled for
+    deployEnvironments :: Maybe [Text],              -- The environments which the `deploy to <environment>` command should be enabled for
+    subprojects        :: Maybe [Text]               -- The subprojects which the `deploy` command should recognize
   }
   deriving (Generic)
 

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -198,7 +198,8 @@ buildProjectConfig repoDir stateFile = Config.ProjectConfiguration {
   Config.checkout           = repoDir,
   Config.stateFile          = stateFile,
   Config.checks             = Just (Config.ChecksConfiguration Set.empty),
-  Config.deployEnvironments = Just ["staging", "production"]
+  Config.deployEnvironments = Just ["staging", "production"],
+  Config.subprojects        = Nothing
 }
 
 -- Dummy user configuration used in test environment.


### PR DESCRIPTION
This PR adds the ability to specify specific subprojects to deploy. This makes it possible to write things like

  - merge and deploy foo
  - merge and deploy foo, bar
  - merge and deploy foo, bar to environment
  - merge and deploy foo, bar on friday

Merge commits will include an additional line `Deploy-Subprojects:` with a value of either `all`, or a comma-separated list of the subprojects to deploy.