### PR TITLE
Increase event queue sizes and log about dropepd events

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,6 +17,7 @@ import Data.Maybe (maybeToList)
 import Data.String (fromString)
 import Data.Version (showVersion)
 import Effectful (runEff)
+import GHC.Natural (Natural)
 import System.Exit (die)
 import System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
 
@@ -52,6 +53,18 @@ import qualified Data.Set as Set
 
 version :: String
 version = showVersion Paths_hoff.version
+
+-- | The number of webhook events Hoff can handle at once. This is shared
+-- between projects.
+webhookQueueSize :: Natural
+webhookQueueSize = 128
+
+-- | The number of queued up events for a single project. This does not need to
+-- be the same size as 'webhookQueueSize', but if we run the risk of filling up
+-- the webhook queue because of a burst of webhook events then there's a decent
+-- chance they're all for the same project.
+projectQueueSize :: Natural
+projectQueueSize = 128
 
 data Options = Options
   { configFilePath :: FilePath
@@ -135,7 +148,7 @@ runMain options = do
   -- low-volume (in the range of ~once per minute) and processing events
   -- should be fast (a few milliseconds, or perhaps a few seconds for a heavy
   -- Git operation), so the queue is expected to be empty most of the time.
-  ghQueue <- Github.newEventQueue 10
+  ghQueue <- Github.newEventQueue webhookQueueSize
 
   -- Each project is treated in isolation, containing their own queue and state.
   let mandatoryChecksFromConfig projectConfig = Project.MandatoryChecks
@@ -148,7 +161,7 @@ runMain options = do
     -- process them. This conversion process does not reject events, but it blocks
     -- if the project queue is full (which will cause the webhook queue to fill
     -- up, so the server will reject new events).
-    projectQueue <- Logic.newEventQueue 10
+    projectQueue <- Logic.newEventQueue projectQueueSize
 
     -- Restore the previous state from disk if possible, or start clean.
     projectState <- initializeProjectState
@@ -179,8 +192,13 @@ runMain options = do
 
   let
     -- When the webhook server receives an event, enqueue it on the webhook
-    -- event queue if it is not full.
-    ghTryEnqueue = Github.tryEnqueueEvent ghQueue
+    -- event queue if it is not full. If it is, then we'll print that to STDOUT.
+    ghTryEnqueue event = do
+      result <- Github.tryEnqueueEvent ghQueue event
+      unless result $
+        putStrLn $ "The GitHub queue is full, dropped the following webhook event: " <> show event
+
+      pure result
 
     -- Allow the webinterface to retrieve the latest project state per project.
     readProjectState = Logic.readStateVar . projectThreadStateVar

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+ * Increased internal event queue sizes from 10 to 128 to reduce the chance of
+   Hoff dropping events when receiving dozens of webhook events at the exact
+   same time.
+ * When Hoff drops a webhook event because its internal event queue is full, it
+   will now log the evenet to STDOUT>
+
 ## 0.31.6
 
 Released 2023-10-05.


### PR DESCRIPTION
This reduces the chance that webhook events are getting lost when Hoff receives a couple dozen of them in one go. The previous queues were bounded to 10 elements. This increases them to 128 elements, and it prints am message to STDOUT if events are dropped so we can set up alerts for that.

CC @bertptrs 