### PR TITLE
Replace 501 with 204. Add logging it.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+* Respond with 204 (NoContent) instead of 501 (UnImplemented) when responding to
+  unsupported event hook types sent by Github. This is to prevent Github from
+  interpreting the responses as errors.
+* Log unsupported event hook types to STDOUT>.
+
+
 ## 0.31.7
 
 Released 2023-10-10.

--- a/tests/ServerSpec.hs
+++ b/tests/ServerSpec.hs
@@ -26,8 +26,7 @@ import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Simple (Response)
 import Network.HTTP.Types.Header (Header, HeaderName, hContentType)
-import Network.HTTP.Types.Status (badRequest400, notFound404, notImplemented501, ok200,
-                                  serviceUnavailable503)
+import Network.HTTP.Types.Status (badRequest400, notFound404, ok200, serviceUnavailable503, noContent204)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
 import qualified Data.ByteString.Char8 as ByteString.Strict
@@ -245,12 +244,10 @@ serverSpec = do
         Http.getResponseStatus goodResponse `shouldBe` ok200
         event `shouldSatisfy` isCommitStatusEvent
 
-    it "serves 501 not implemented for unknown webhooks" $
+    it "serves 204 no content for unknown webhooks" $
       withServer $ \ _ghQueue -> do
         payload  <- ByteString.Lazy.readFile "tests/data/pull-request-payload.json"
         -- Send a webhook event with correct signature, but bogus event name.
         response <- httpPostGithubEvent "/hook/github" "launch_missiles" payload
         let status = Http.getResponseStatus response
-            msg    = Http.getResponseBody response
-        status `shouldBe` notImplemented501
-        msg    `shouldBe` "hook ignored, the event type is not supported"
+        status `shouldBe` noContent204


### PR DESCRIPTION
Addresses: #193 

Un-handled event names are made to respond with a 204 (NoContent) instead of a 501 to GitHub.

This is because GitHub is interpreting those 501s as an error and cluttering the UI.

The unhandled event names and id's are logged out. Hopefully in a thread safe, line buffered way, using putStr, since putStrLn is not thread-safe. @crtschin pointed this out and also shared this blog post:
https://www.snoyman.com/blog/2016/11/haskells-missing-concurrency-basics/

