### PR TITLE
Allow commands from pr description

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.31.9
+
+Released 2023-10-23
+
+  * Allow a merge command in the description of a merge request, to be able to
+    directly create a pull request and approve it for merging.
+
 ## 0.31.8
 
 Released 2023-10-16

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,6 +1,6 @@
 name:                hoff
 -- please keep version consistent with hoff.nix
-version:             0.31.8
+version:             0.31.9
 category:            Development
 synopsis:            A gatekeeper for your commits
 

--- a/hoff.nix
+++ b/hoff.nix
@@ -16,7 +16,7 @@ pkgs, mkDerivation
 , wai-middleware-prometheus, warp, warp-tls }:
 mkDerivation {
   pname = "hoff";
-  version = "0.31.8"; # please keep consistent with hoff.cabal
+  version = "0.31.9"; # please keep consistent with hoff.cabal
 
   src = let
     # We do not want to include all files, because that leads to a lot of things

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -50,13 +50,18 @@ eventFromPullRequestPayload payload =
     number = PullRequestId payload.number
     title  = payload.title
     author = payload.author
+    body   = payload.body
     branch = payload.branch
     sha    = payload.sha
     baseBranch = Github.baseBranch (payload :: PullRequestPayload)
   in
     case payload.action of
-      Github.Opened      -> Logic.PullRequestOpened number branch baseBranch sha title author
-      Github.Reopened    -> Logic.PullRequestOpened number branch baseBranch sha title author
+      Github.Opened      -> Logic.PullRequestOpened number branch baseBranch sha title author body
+      -- If the pull request is reopened, we do not want to parse the command from
+      -- the body, because it means that a person manually intervened with the pull
+      -- request. This is why we do not pass the body to the event, so we don't
+      -- accidentally repeatedly process the same command.
+      Github.Reopened    -> Logic.PullRequestOpened number branch baseBranch sha title author Nothing
       Github.Closed      -> Logic.PullRequestClosed number
       Github.Synchronize -> Logic.PullRequestCommitChanged number sha
       Github.Edited      -> Logic.PullRequestEdited number title baseBranch

--- a/src/Github.hs
+++ b/src/Github.hs
@@ -37,7 +37,7 @@ import GHC.Natural (Natural)
 
 import Git (Sha (..), Branch (..), BaseBranch (..), Context)
 import Project (ProjectInfo (..))
-import Types (Username)
+import Types (Body, Username)
 import Data.Maybe (fromMaybe)
 
 data PullRequestAction
@@ -69,14 +69,15 @@ data CommitStatus
 
 data PullRequestPayload = PullRequestPayload {
   action      :: PullRequestAction, -- Corresponds to "action".
-  owner       :: Text,     -- Corresponds to "pull_request.base.repo.owner.login".
-  repository  :: Text,     -- Corresponds to "pull_request.base.repo.name".
-  baseBranch  :: BaseBranch,   -- Corresponds to "pull_request.base.ref"
-  number      :: Int,      -- Corresponds to "pull_request.number".
-  branch      :: Branch,   -- Corresponds to "pull_request.head.ref".
-  sha         :: Sha,      -- Corresponds to "pull_request.head.sha".
-  title       :: Text,     -- Corresponds to "pull_request.title".
-  author      :: Username  -- Corresponds to "pull_request.user.login".
+  owner       :: Text,       -- Corresponds to "pull_request.base.repo.owner.login".
+  repository  :: Text,       -- Corresponds to "pull_request.base.repo.name".
+  baseBranch  :: BaseBranch, -- Corresponds to "pull_request.base.ref"
+  number      :: Int,        -- Corresponds to "pull_request.number".
+  branch      :: Branch,     -- Corresponds to "pull_request.head.ref".
+  sha         :: Sha,        -- Corresponds to "pull_request.head.sha".
+  title       :: Text,       -- Corresponds to "pull_request.title".
+  author      :: Username,   -- Corresponds to "pull_request.user.login".
+  body        :: Maybe Body  -- Corresponds to "pull_request.body"
 } deriving (Eq, Show)
 
 data CommentPayload = CommentPayload {
@@ -152,6 +153,7 @@ instance FromJSON PullRequestPayload where
     <*> getNested v ["pull_request", "head", "sha"]
     <*> getNested v ["pull_request", "title"]
     <*> getNested v ["pull_request", "user", "login"]
+    <*> getNested v ["pull_request", "body"]
   parseJSON nonObject = typeMismatch "pull_request payload" nonObject
 
 instance FromJSON CommentPayload where

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -11,6 +11,7 @@
 
 module Types
 (
+  Body (..),
   PullRequestId (..),
   Username (..),
 )
@@ -30,8 +31,13 @@ newtype Username = Username Text deriving (Eq, Show, Generic, IsString, Buildabl
 -- A pull request is identified by its number.
 newtype PullRequestId = PullRequestId Int deriving (Eq, Ord, Show, Generic)
 
+-- The body of a pull request
+newtype Body = Body Text deriving (Eq, Show, Generic, IsString, Buildable)
+
+instance FromJSON Body
 instance FromJSON PullRequestId
 instance FromJSON Username
 
+instance ToJSON Body where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON PullRequestId where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON Username where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions


### PR DESCRIPTION
Allow merge commands to be part of the pull request description by handling the description of the pull request as an added comment.

resolves #239 
