### PR TITLE
Disallow implicit deployment environment selection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.31.11
+
+Release 2023-10-26
+
+  - Disallow `merge and deploy` without a specified environment if multiple environments are available.
+
 ## 0.31.10
 
 Released 2023-10-26

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -571,7 +571,7 @@ eventLoopSpec = parallel $ do
         -- commit. A new tag `v2` should appear.
         state <- runLoop Project.emptyProjectState
           [ Logic.PullRequestOpened pr4 branch baseBranch c4 "Deploy tests!" "deckard" Nothing
-          , Logic.CommentAdded pr4 "rachael" "@bot merge and deploy"
+          , Logic.CommentAdded pr4 "rachael" "@bot merge and deploy to staging"
           ]
 
         -- Extract the sha of the rebased commit from the project state.
@@ -727,7 +727,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr6 branch baseBranch c6 "Deploy it now!" "deckard" Nothing,
-            Logic.CommentAdded pr6 "rachael" "@bot merge and deploy"
+            Logic.CommentAdded pr6 "rachael" "@bot merge and deploy to staging"
           ]
 
         let [rebasedSha] = integrationShas state


### PR DESCRIPTION
This disallows `merge and deploy` without specifying an environment, if multiple deployment environments are configured.
For repositories with no or a single configured deployment environment, nothing changes.
I added tests for this behavior.