### PR TITLE
Always create a merge commit if a PR is approved for merge and tag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.31.10
+
+Released 2023-10-26
+
+  - Always create merge commits when a single-commit PR is approved for merge and tag.
+
 ## 0.31.9
 
 Released 2023-10-23

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,6 +1,6 @@
 name:                hoff
 -- please keep version consistent with hoff.nix
-version:             0.31.9
+version:             0.31.10
 category:            Development
 synopsis:            A gatekeeper for your commits
 

--- a/hoff.nix
+++ b/hoff.nix
@@ -16,7 +16,7 @@ pkgs, mkDerivation
 , wai-middleware-prometheus, warp, warp-tls }:
 mkDerivation {
   pname = "hoff";
-  version = "0.31.9"; # please keep consistent with hoff.cabal
+  version = "0.31.10"; # please keep consistent with hoff.cabal
 
   src = let
     # We do not want to include all files, because that leads to a lot of things

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -532,10 +532,11 @@ displayMergeCommand (Approve (MergeAndDeploy (DeployEnvironment env))) = format 
 displayMergeCommand (Approve MergeAndTag)                              = "merge and tag"
 displayMergeCommand Retry                                              = "retry"
 
+-- | Whether the specified approval type requires a merge commit to be created.
+-- This is currently the case if a tag is to be created, because the deployment
+-- instructions are recorded in the merge commit's message.
 alwaysAddMergeCommit :: ApprovedFor -> Bool
-alwaysAddMergeCommit Merge              = False
-alwaysAddMergeCommit (MergeAndDeploy _) = True
-alwaysAddMergeCommit MergeAndTag        = False
+alwaysAddMergeCommit = needsTag
 
 needsDeploy :: ApprovedFor -> Bool
 needsDeploy Merge              = False

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1003,7 +1003,7 @@ main = hspec $ do
         [ AIsReviewer "deckard"
         , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and tag by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
-                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
         , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
@@ -1024,7 +1024,7 @@ main = hspec $ do
         [ AIsReviewer "deckard"
         , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and tag by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
-                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
         , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
@@ -1045,7 +1045,7 @@ main = hspec $ do
         [ AIsReviewer "deckard"
         , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and tag by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
-                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
         , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
@@ -1066,7 +1066,7 @@ main = hspec $ do
         [ AIsReviewer "deckard"
         , ALeaveComment prId "<!-- Hoff: ignore -->\nPull request approved for merge and tag by @deckard, rebasing now."
         , ATryIntegrate "Merge #1: Untitled\n\nApproved-by: deckard\nAuto-deploy: false\n"
-                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] False
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "abc1234") [] True
         , ALeaveComment prId "<!-- Hoff: ignore -->\nRebased as def2345, waiting for CI \x2026"
         ]
 
@@ -1923,7 +1923,7 @@ main = hspec $ do
       actions `shouldBe`
         [ ATryPromoteWithTag (Branch "results/rachael") (Sha "38d") (TagName "v2") (TagMessage "v2\n\nchangelog")
         , ATryIntegrate "Merge #1: Add my test results\n\nApproved-by: deckard\nAuto-deploy: false\n"
-                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "f35") [] False
+                        (PullRequestId 1, Branch "refs/pull/1/head", Sha "f35") [] True
         , ALeaveComment (PullRequestId 1) "<!-- Hoff: ignore -->\nRebased as 38e, waiting for CI \x2026"
         ]
 


### PR DESCRIPTION
This PR alters Hoff's merge logic to always create a merge commit if a tag is to be created after merging.
This fixes an issue where our deploy automation breaks if a single-commit PR is merge and tagged, because the required approver information is recorded in the merge commit's message.