### PR TITLE
Add feature-freeze configuration option

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -253,6 +253,7 @@ projectThread config options metrics projectThreadData = do
           (Config.trigger config)
           projectConfig
           (Config.mergeWindowExemption config)
+          (Config.featureFreezeWindow config)
           getNextEvent
           publish
           projectThreadState

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.32.0
+
+Release 2023-11-07
+
+  - Add `featureFreezeWindow` configuration option. During a configured feature freeze, only commands suffixed with `as hotfix` are allowed. The feature is similar to the `on friday` feature.
+
 ## 0.31.11
 
 Release 2023-10-26

--- a/doc/example-dev-config.json
+++ b/doc/example-dev-config.json
@@ -30,5 +30,9 @@
   "metrics": {
     "metricsPort": 3333,
     "metricsHost": "*"
+  },
+  "featureFreezeWindow": {
+    "start": "2023-01-01T00:00:00Z",
+    "end": "2023-01-07T00:00:00Z"
   }
 }

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,6 +1,6 @@
 name:                hoff
 -- please keep version consistent with hoff.nix
-version:             0.31.11
+version:             0.32.0
 category:            Development
 synopsis:            A gatekeeper for your commits
 

--- a/hoff.nix
+++ b/hoff.nix
@@ -16,7 +16,7 @@ pkgs, mkDerivation
 , wai-middleware-prometheus, warp, warp-tls }:
 mkDerivation {
   pname = "hoff";
-  version = "0.31.11"; # please keep consistent with hoff.cabal
+  version = "0.32.0"; # please keep consistent with hoff.cabal
 
   src = let
     # We do not want to include all files, because that leads to a lot of things

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -26,5 +26,9 @@
   "mergeWindowExemption": ["hoffbot"],
   "trigger": {
     "commentPrefix": "@hoffbot"
+  },
+  "featureFreezeWindow": {
+    "start": "2023-01-01T00:00:00Z",
+    "end": "2023-01-07T00:00:00Z"
   }
 }

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -17,6 +17,7 @@ module Configuration
   UserConfiguration (..),
   MergeWindowExemptionConfiguration (..),
   MetricsConfiguration (..),
+  FeatureFreezeWindow (..),
   loadConfiguration
 )
 where
@@ -25,6 +26,7 @@ import Data.Aeson (FromJSON, eitherDecodeStrict')
 import Data.ByteString (readFile)
 import Data.Set (Set)
 import Data.Text (Text)
+import Data.Time (UTCTime)
 import GHC.Generics
 import Prelude hiding (readFile)
 import qualified Network.Wai.Handler.Warp as Warp
@@ -39,6 +41,13 @@ data ProjectConfiguration = ProjectConfiguration
     stateFile          :: FilePath,                  -- The file where project state is stored.
     checks             :: Maybe ChecksConfiguration, -- Optional configuration related to checks for the project.
     deployEnvironments :: Maybe [Text]               -- The environments which the `deploy to <environment>` command should be enabled for
+  }
+  deriving (Generic)
+
+data FeatureFreezeWindow = FeatureFreezeWindow
+  {
+    start :: UTCTime,
+    end   :: UTCTime
   }
   deriving (Generic)
 
@@ -122,7 +131,10 @@ data Configuration = Configuration
     mergeWindowExemption :: MergeWindowExemptionConfiguration,
 
     -- Configuration for the Prometheus metrics server.
-    metricsConfig :: Maybe MetricsConfiguration
+    metricsConfig :: Maybe MetricsConfiguration,
+
+    -- Feature freeze period in which only 'merge hotfix' commands are allowed
+    featureFreezeWindow :: Maybe FeatureFreezeWindow
   }
   deriving (Generic)
 
@@ -134,6 +146,7 @@ instance FromJSON TriggerConfiguration
 instance FromJSON UserConfiguration
 instance FromJSON MergeWindowExemptionConfiguration
 instance FromJSON MetricsConfiguration
+instance FromJSON FeatureFreezeWindow
 
 -- Reads and parses the configuration. Returns Nothing if parsing failed, but
 -- crashes if the file could not be read.

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -29,7 +29,7 @@ import Data.Text (Text)
 import Effectful (Eff, (:>), IOE)
 import qualified Data.Text as Text
 
-import Configuration (ProjectConfiguration, TriggerConfiguration, MergeWindowExemptionConfiguration)
+import Configuration (ProjectConfiguration, TriggerConfiguration, MergeWindowExemptionConfiguration, FeatureFreezeWindow)
 import Github (PullRequestPayload, CommentPayload, CommitStatusPayload, PushPayload, WebhookEvent (..))
 import Github (eventProjectInfo)
 import MonadLoggerEffect (MonadLoggerEffect)
@@ -137,6 +137,7 @@ runLogicEventLoop
   => TriggerConfiguration
   -> ProjectConfiguration
   -> MergeWindowExemptionConfiguration
+  -> Maybe FeatureFreezeWindow
   -- Action that gets the next event from the queue.
   -> IO (Maybe Logic.Event)
   -- Action to perform after the state has changed, such as
@@ -146,7 +147,7 @@ runLogicEventLoop
   -> ProjectState
   -> Eff es ProjectState
 runLogicEventLoop
-  triggerConfig projectConfig mergeWindowExemptionConfig
+  triggerConfig projectConfig mergeWindowExemptionConfig featureFreezeWindow
   getNextEvent publish initialState =
   let
     repo             = Config.repository projectConfig
@@ -156,7 +157,7 @@ runLogicEventLoop
       -- perform).
       logInfoN  $ "logic loop received event (" <> repo <> "): " <> showText event
       state1 <-
-        Logic.handleEvent triggerConfig mergeWindowExemptionConfig event state0
+        Logic.handleEvent triggerConfig mergeWindowExemptionConfig featureFreezeWindow event state0
       liftIO $ publish state1
       runLoop state1
 

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -188,7 +188,7 @@ data Approval = Approval
   }
   deriving (Eq, Show, Generic)
 
-data MergeWindow = OnFriday | NotFriday
+data MergeWindow = OnFriday | DuringFeatureFreeze | AnyDay
   deriving (Show)
 
 -- | A check is a key we check incoming build status contexts (in the case of

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -39,7 +39,7 @@ import qualified Data.Map as Map
 import qualified Data.Time as T
 import qualified Data.Time.Calendar.OrdinalDate as T
 
-import Configuration (ProjectConfiguration, TriggerConfiguration, UserConfiguration, MergeWindowExemptionConfiguration (..))
+import Configuration (ProjectConfiguration, TriggerConfiguration, UserConfiguration, MergeWindowExemptionConfiguration (..), FeatureFreezeWindow)
 import Git (BaseBranch (..), Branch (..), RefSpec (refSpec), Sha (..))
 import Metrics.Metrics (MetricsOperation (..))
 import Project (BuildStatus (..), IntegrationStatus (..), ProjectState, PullRequestId (..))
@@ -218,6 +218,9 @@ triggerConfig = Config.TriggerConfiguration {
 mergeWindowExemptionConfig :: MergeWindowExemptionConfiguration
 mergeWindowExemptionConfig = MergeWindowExemptionConfiguration ["bot"]
 
+featureFreezeWindow :: Maybe FeatureFreezeWindow
+featureFreezeWindow = Nothing
+
 -- An interpreter for the GitHub API free monad that ignores most API calls, and
 -- provides fake inputs. We don't want to require a Github repository and API
 -- token to be able to run the tests, and that we send the right operations is
@@ -277,6 +280,7 @@ runMainEventLoop projectConfig initialState events = do
         triggerConfig
         projectConfig
         mergeWindowExemptionConfig
+        featureFreezeWindow
         getNextEvent
         publish
         initialState


### PR DESCRIPTION
Closes https://github.com/channable/hoff/issues/243

This adds a configuration option, called `featureFreezePeriod`.

In the configured feature freeze period:
- Normal `merge` commands are blocked;
- Instead, `merge hotfix` commands are allowed;
- `merge and (tag | deploy)` becomes `merge hotfix and (tag | deploy)`
- Using `merge hotfix` outside of the configured feature freeze period is not allowed.

A few choices I made here:
- The default `on Friday` suffix is not necessary during a feature freeze, to keep it simple;
- For the `retry` command, neither `on Friday` nor `hotfix` is necessary to specify;
- The feature freeze period is configured globally, not per project.