### PR TITLE
Atomically push the result of rebasing to master and the PR branch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.32.1
+
+Release 2023-11-28
+
+  - Push integration results atomically to avoid PRs being closed incorreclty.
+
 ## 0.32.0
 
 Release 2023-11-07

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,6 +1,6 @@
 name:                hoff
 -- please keep version consistent with hoff.nix
-version:             0.32.0
+version:             0.32.1
 category:            Development
 synopsis:            A gatekeeper for your commits
 

--- a/hoff.nix
+++ b/hoff.nix
@@ -16,7 +16,7 @@ pkgs, mkDerivation
 , wai-middleware-prometheus, warp, warp-tls }:
 mkDerivation {
   pname = "hoff";
-  version = "0.32.0"; # please keep consistent with hoff.cabal
+  version = "0.32.1"; # please keep consistent with hoff.cabal
 
   src = let
     # We do not want to include all files, because that leads to a lot of things

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -136,10 +136,13 @@ instance RefSpec (Sha, BaseBranch) where
 instance RefSpec TagName where
   refSpec (TagName name) = Text.unpack name
 
-data SomeRefSpec = forall a . RefSpec a => AsRefSpec a
+data SomeRefSpec
+  = forall a . RefSpec a => AsRefSpec a
+  | forall a . RefSpec a => AsRefSpecForce a
 
 instance RefSpec SomeRefSpec where
   refSpec (AsRefSpec a) = refSpec a
+  refSpec (AsRefSpecForce a) = "+" ++ refSpec a
 
 instance FromJSON Branch where
   parseJSON (String str) = return (Branch str)

--- a/src/Time.hs
+++ b/src/Time.hs
@@ -2,10 +2,8 @@
 {-# LANGUAGE GHC2021 #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
-module Time (getDateTime, sleepMicros, runTime, TimeOperation (..)) where
+module Time (getDateTime, runTime, TimeOperation (..)) where
 
-import Control.Concurrent (threadDelay)
-import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Time (UTCTime, getCurrentTime)
 import Effectful (Dispatch (Dynamic), DispatchOf, Eff, Effect, IOE, (:>))
@@ -13,17 +11,12 @@ import Effectful.Dispatch.Dynamic (interpret, send)
 
 data TimeOperation :: Effect where
   GetDateTime :: TimeOperation m UTCTime
-  SleepMicros :: Int -> TimeOperation m ()
 
 type instance DispatchOf TimeOperation = 'Dynamic
 
 getDateTime :: TimeOperation :> es => Eff es UTCTime
 getDateTime = send GetDateTime
 
-sleepMicros :: TimeOperation :> es => Int -> Eff es ()
-sleepMicros micros = send $ SleepMicros micros
-
 runTime :: IOE :> es => Eff (TimeOperation : es) a -> Eff es a
 runTime = interpret $ \_ -> \case
   GetDateTime -> liftIO getCurrentTime
-  SleepMicros micros -> void $ liftIO (threadDelay micros)

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -236,7 +236,6 @@ fakeRunGithub = interpret $ \_ -> \case
 fakeRunTime :: Eff (Time.TimeOperation : es) a -> Eff es a
 fakeRunTime = interpret $ \_ -> \case
   Time.GetDateTime -> pure $ T.UTCTime (T.fromMondayStartWeek 2021 2 1) (T.secondsToDiffTime 0)
-  Time.SleepMicros _ -> pure ()
 
 fakeRunMetrics :: Eff (MetricsOperation : es) a -> Eff es a
 fakeRunMetrics = interpret $ \_ -> \case


### PR DESCRIPTION
We now atomically push the result of integrating to the main branch and the PR branch. This should hopefully avoid the problem from #196. By pushing atomically, we hope that GitHub will handle both pushes at the same time and only check for the merging/closing after both have been handled.