### PR TITLE
Wait with push to master until PR is updated

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.32.2
+
+Release 2023-12-14
+
+  - Wait with promoting to master until the PR has been updated after the force push.
+
 ## 0.32.1
 
 Release 2023-11-28

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,6 +1,6 @@
 name:                hoff
 -- please keep version consistent with hoff.nix
-version:             0.32.1
+version:             0.32.2
 category:            Development
 synopsis:            A gatekeeper for your commits
 
@@ -19,7 +19,8 @@ library
   default-language: Haskell2010
   ghc-options:     -Wall -Werror -Wincomplete-uni-patterns -Wincomplete-record-updates -fno-ignore-asserts
   hs-source-dirs:  src
-  exposed-modules: Configuration
+  exposed-modules: ClockTickLoop
+                 , Configuration
                  , EventLoop
                  , Format
                  , Git

--- a/hoff.nix
+++ b/hoff.nix
@@ -16,7 +16,7 @@ pkgs, mkDerivation
 , wai-middleware-prometheus, warp, warp-tls }:
 mkDerivation {
   pname = "hoff";
-  version = "0.32.1"; # please keep consistent with hoff.cabal
+  version = "0.32.2"; # please keep consistent with hoff.cabal
 
   src = let
     # We do not want to include all files, because that leads to a lot of things

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -30,5 +30,6 @@
   "featureFreezeWindow": {
     "start": "2023-01-01T00:00:00Z",
     "end": "2023-01-07T00:00:00Z"
-  }
+  },
+  "promotionTimeout": 60
 }

--- a/src/ClockTickLoop.hs
+++ b/src/ClockTickLoop.hs
@@ -1,0 +1,36 @@
+module ClockTickLoop
+  ( clockTickLoop
+  ) where
+
+import Control.Concurrent (threadDelay)
+import Control.Monad (void)
+import Control.Monad.IO.Class (liftIO, MonadIO)
+import Data.Time (getCurrentTime)
+import Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
+
+import Configuration (ClockTickInterval (..))
+import Logic (EventQueue, enqueueEvent, Event (ClockTick))
+
+foreverWithDelay :: MonadIO m => DiffTime -> m a -> m b
+foreverWithDelay delay action = go
+  where
+    go = do
+      void $ action
+      liftIO $ threadDelay $ fromInteger $ diffTimeToMicroseconds delay
+      go
+
+-- | Creates a loop that every interval sends a clock tick event
+-- to check for timed out PRs that are waiting to be promoted.
+clockTickLoop
+  :: MonadIO m
+  => ClockTickInterval
+  -> [EventQueue]
+  -> m a
+clockTickLoop (ClockTickInterval tickInterval) queues = do
+  foreverWithDelay tickInterval $ do
+    currentTime <- liftIO getCurrentTime
+    liftIO $ mapM_ (`enqueueEvent` ClockTick currentTime) queues
+
+-- A picosecond is 1e-12 seconds, a microsecond is 1e-6 seconds.
+diffTimeToMicroseconds :: DiffTime -> Integer
+diffTimeToMicroseconds t = diffTimeToPicoseconds t `div` (1000 * 1000)

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -18,6 +18,8 @@ module Configuration
   MergeWindowExemptionConfiguration (..),
   MetricsConfiguration (..),
   FeatureFreezeWindow (..),
+  PromotionTimeout (..),
+  ClockTickInterval (..),
   loadConfiguration
 )
 where
@@ -26,7 +28,7 @@ import Data.Aeson (FromJSON, eitherDecodeStrict')
 import Data.ByteString (readFile)
 import Data.Set (Set)
 import Data.Text (Text)
-import Data.Time (UTCTime)
+import Data.Time (DiffTime, UTCTime)
 import GHC.Generics
 import Prelude hiding (readFile)
 import qualified Network.Wai.Handler.Warp as Warp
@@ -98,6 +100,12 @@ data MetricsConfiguration = MetricsConfiguration
 newtype MergeWindowExemptionConfiguration = MergeWindowExemptionConfiguration [Text]
   deriving (Generic, Show)
 
+newtype PromotionTimeout = PromotionTimeout DiffTime
+  deriving (Generic, Show)
+
+newtype ClockTickInterval = ClockTickInterval DiffTime
+  deriving (Generic, Show)
+
 data Configuration = Configuration
   {
     -- The projects to manage.
@@ -134,7 +142,13 @@ data Configuration = Configuration
     metricsConfig :: Maybe MetricsConfiguration,
 
     -- Feature freeze period in which only 'merge hotfix' commands are allowed
-    featureFreezeWindow :: Maybe FeatureFreezeWindow
+    featureFreezeWindow :: Maybe FeatureFreezeWindow,
+
+    -- The timeout for promoting an integrated pull request
+    promotionTimeout :: PromotionTimeout,
+
+    -- The interval to send clock tick events
+    clockTickInterval :: Maybe ClockTickInterval
   }
   deriving (Generic)
 
@@ -147,6 +161,8 @@ instance FromJSON UserConfiguration
 instance FromJSON MergeWindowExemptionConfiguration
 instance FromJSON MetricsConfiguration
 instance FromJSON FeatureFreezeWindow
+instance FromJSON PromotionTimeout
+instance FromJSON ClockTickInterval
 
 -- Reads and parses the configuration. Returns Nothing if parsing failed, but
 -- crashes if the file could not be read.

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -29,7 +29,7 @@ import Data.Text (Text)
 import Effectful (Eff, (:>), IOE)
 import qualified Data.Text as Text
 
-import Configuration (ProjectConfiguration, TriggerConfiguration, MergeWindowExemptionConfiguration, FeatureFreezeWindow)
+import Configuration (ProjectConfiguration, TriggerConfiguration, MergeWindowExemptionConfiguration, FeatureFreezeWindow, PromotionTimeout)
 import Github (PullRequestPayload, CommentPayload, CommitStatusPayload, PushPayload, WebhookEvent (..))
 import Github (eventProjectInfo)
 import MonadLoggerEffect (MonadLoggerEffect)
@@ -138,6 +138,7 @@ runLogicEventLoop
   -> ProjectConfiguration
   -> MergeWindowExemptionConfiguration
   -> Maybe FeatureFreezeWindow
+  -> PromotionTimeout
   -- Action that gets the next event from the queue.
   -> IO (Maybe Logic.Event)
   -- Action to perform after the state has changed, such as
@@ -147,7 +148,7 @@ runLogicEventLoop
   -> ProjectState
   -> Eff es ProjectState
 runLogicEventLoop
-  triggerConfig projectConfig mergeWindowExemptionConfig featureFreezeWindow
+  triggerConfig projectConfig mergeWindowExemptionConfig featureFreezeWindow promotionTimeout
   getNextEvent publish initialState =
   let
     repo             = Config.repository projectConfig
@@ -157,7 +158,7 @@ runLogicEventLoop
       -- perform).
       logInfoN  $ "logic loop received event (" <> repo <> "): " <> showText event
       state1 <-
-        Logic.handleEvent triggerConfig mergeWindowExemptionConfig featureFreezeWindow event state0
+        Logic.handleEvent triggerConfig mergeWindowExemptionConfig featureFreezeWindow promotionTimeout event state0
       liftIO $ publish state1
       runLoop state1
 

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -136,13 +136,10 @@ instance RefSpec (Sha, BaseBranch) where
 instance RefSpec TagName where
   refSpec (TagName name) = Text.unpack name
 
-data SomeRefSpec
-  = forall a . RefSpec a => AsRefSpec a
-  | forall a . RefSpec a => AsRefSpecForce a
+data SomeRefSpec = forall a . RefSpec a => AsRefSpec a
 
 instance RefSpec SomeRefSpec where
   refSpec (AsRefSpec a) = refSpec a
-  refSpec (AsRefSpecForce a) = "+" ++ refSpec a
 
 instance FromJSON Branch where
   parseJSON (String str) = return (Branch str)
@@ -164,6 +161,20 @@ instance FromJSON Sha where
 
 instance ToJSON Sha where
   toJSON (Sha str) = String str
+
+instance FromJSON TagName where
+  parseJSON (String str) = return (TagName str)
+  parseJSON _            = mzero
+
+instance ToJSON TagName where
+  toJSON (TagName str) = String str
+
+instance FromJSON TagMessage where
+  parseJSON (String str) = return (TagMessage str)
+  parseJSON _            = mzero
+
+instance ToJSON TagMessage where
+  toJSON (TagMessage str) = String str
 
 instance FromJSON RemoteUrl where
   parseJSON (String url) = pure (RemoteUrl url)

--- a/src/Time.hs
+++ b/src/Time.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE GHC2021 #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
-module Time (getDateTime, runTime, TimeOperation (..)) where
+module Time (addTime, getDateTime, runTime, TimeOperation (..)) where
 
 import Control.Monad.IO.Class (liftIO)
-import Data.Time (UTCTime, getCurrentTime)
+import Data.Time (DiffTime, UTCTime, addUTCTime, getCurrentTime)
 import Effectful (Dispatch (Dynamic), DispatchOf, Eff, Effect, IOE, (:>))
 import Effectful.Dispatch.Dynamic (interpret, send)
 
@@ -20,3 +20,6 @@ getDateTime = send GetDateTime
 runTime :: IOE :> es => Eff (TimeOperation : es) a -> Eff es a
 runTime = interpret $ \_ -> \case
   GetDateTime -> liftIO getCurrentTime
+
+addTime :: UTCTime -> DiffTime -> UTCTime
+addTime t d = addUTCTime (realToFrac d) t

--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -290,6 +290,8 @@ viewPullRequestWithApproval info prId pullRequest = do
               _                          -> pure ()
           Conflicted _ _      -> span "  | " >> span "❗ Conflicted"
           IncorrectBaseBranch -> span "  | " >> span "❗ Incorrect base branch"
+          Promote _ _         -> span "  | " >> span "Awaiting promotion"
+          PromoteAndTag {}    -> span "  | " >> span "Awaiting promotion"
           -- Promotions are not actually shown in the interface
           -- as a PR is deleted right after it is promoted.
           -- The case is here so we cover all branches


### PR DESCRIPTION
After force pushing to the PR branch we wait until we receive the GitHub event that the commit for the PR has changed before pushing to master. If this event takes too long to arrive we push to master anyway.

Resolves #196 
