### PR TITLE
Add missing 'promotionTimeout' field also to doc/example-dev-config.json

### DIFF
--- a/doc/example-dev-config.json
+++ b/doc/example-dev-config.json
@@ -34,5 +34,6 @@
   "featureFreezeWindow": {
     "start": "2023-01-01T00:00:00Z",
     "end": "2023-01-07T00:00:00Z"
-  }
+  },
+  "promotionTimeout": 60
 }


### PR DESCRIPTION
When currently following the 'Running as a developer' steps in the README, Hoff does not start but instead throws the following error:

```
$ cabal run hoff config.json 
Starting Hoff v0.32.2
Config file: config.json
Read-only: False
Failed to parse configuration file 'config.json'.
Error in $: parsing Configuration.Configuration(Configuration) failed, key "promotionTimeout" not found
```

Seems that the `promotionTimeout` field exists in `package/example-config.json` but it is still missing in `doc/example-dev-config.json`.

This PR copies the missing field to `doc/example-dev-config.json` to make sure building-and-running Just Works :tm: for other devs in the future.