### PR TITLE
Subprojects in merge commands

### DIFF
--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -11,6 +11,8 @@ module Configuration
 (
   Configuration (..),
   ProjectConfiguration (..),
+  knownEnvironments,
+  knownSubprojects,
   ChecksConfiguration (..),
   TlsConfiguration (..),
   TriggerConfiguration (..),
@@ -26,6 +28,7 @@ where
 
 import Data.Aeson (FromJSON, eitherDecodeStrict')
 import Data.ByteString (readFile)
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time (DiffTime, UTCTime)
@@ -42,9 +45,16 @@ data ProjectConfiguration = ProjectConfiguration
     checkout           :: FilePath,                  -- The path to a local checkout of the repository.
     stateFile          :: FilePath,                  -- The file where project state is stored.
     checks             :: Maybe ChecksConfiguration, -- Optional configuration related to checks for the project.
-    deployEnvironments :: Maybe [Text]               -- The environments which the `deploy to <environment>` command should be enabled for
+    deployEnvironments :: Maybe [Text],              -- The environments which the `deploy to <environment>` command should be enabled for
+    deploySubprojects  :: Maybe [Text]               -- The subprojects which the `deploy` command should be enabled for
   }
   deriving (Generic)
+
+knownEnvironments :: ProjectConfiguration -> [Text]
+knownEnvironments = fromMaybe [] . deployEnvironments
+
+knownSubprojects :: ProjectConfiguration -> [Text]
+knownSubprojects = fromMaybe [] . deploySubprojects
 
 data FeatureFreezeWindow = FeatureFreezeWindow
   {

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -20,6 +20,7 @@ module Project
   MergeCommand (..),
   BuildStatus (..),
   DeployEnvironment(..),
+  DeploySubprojects(..),
   MandatoryChecks (..),
   Check (..),
   IntegrationStatus (..),
@@ -103,6 +104,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
 
 import Types (PullRequestId (..), Username)
 import Data.Time (UTCTime)
@@ -169,12 +171,17 @@ data PullRequestStatus
 newtype DeployEnvironment = DeployEnvironment Text
   deriving (Eq, Show, Generic)
 
+data DeploySubprojects
+  = EntireProject
+  | OnlySubprojects [Text]
+  deriving (Eq, Show, Generic)
+
 -- | A PR can be approved to be merged with "<prefix> merge", or it can be
 -- approved to be merged and also deployed with "<prefix> merge and deploy".
 -- This enumeration distinguishes these cases.
 data ApprovedFor
   = Merge
-  | MergeAndDeploy DeployEnvironment
+  | MergeAndDeploy DeploySubprojects DeployEnvironment
   | MergeAndTag
   deriving (Eq, Show, Generic)
 
@@ -266,6 +273,7 @@ instance Buildable ProjectInfo where
 instance FromJSON BuildStatus
 instance FromJSON IntegrationStatus
 instance FromJSON DeployEnvironment
+instance FromJSON DeploySubprojects
 instance FromJSON ApprovedFor
 instance FromJSON Approval
 instance FromJSON ProjectState
@@ -274,6 +282,7 @@ instance FromJSON PullRequest
 instance ToJSON BuildStatus where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON IntegrationStatus where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON DeployEnvironment where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+instance ToJSON DeploySubprojects where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON ApprovedFor where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON Approval where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON ProjectState where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
@@ -542,7 +551,11 @@ getOwners = nub . map owner
 -- friday@ merge window suffix.
 displayMergeCommand :: MergeCommand -> Text
 displayMergeCommand (Approve Merge)                                    = "merge"
-displayMergeCommand (Approve (MergeAndDeploy (DeployEnvironment env))) = format "merge and deploy to {}" [env]
+displayMergeCommand (Approve (MergeAndDeploy subprojects (DeployEnvironment env))) =
+  case subprojects of
+    EntireProject      -> format "merge and deploy to {}" [env]
+    OnlySubprojects ss  -> let subs = T.intercalate ", " ss
+                            in format "merge and deploy {} to {}" (subs, env)
 displayMergeCommand (Approve MergeAndTag)                              = "merge and tag"
 displayMergeCommand Retry                                              = "retry"
 
@@ -554,12 +567,12 @@ alwaysAddMergeCommit = needsTag
 
 needsDeploy :: ApprovedFor -> Bool
 needsDeploy Merge              = False
-needsDeploy (MergeAndDeploy _) = True
+needsDeploy MergeAndDeploy{}   = True
 needsDeploy MergeAndTag        = False
 
 needsTag :: ApprovedFor -> Bool
 needsTag Merge              = False
-needsTag (MergeAndDeploy _) = True
+needsTag MergeAndDeploy{}   = True
 needsTag MergeAndTag        = True
 
 integrationSha :: PullRequest -> Maybe Sha

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -198,7 +198,8 @@ buildProjectConfig repoDir stateFile = Config.ProjectConfiguration {
   Config.checkout           = repoDir,
   Config.stateFile          = stateFile,
   Config.checks             = Just (Config.ChecksConfiguration Set.empty),
-  Config.deployEnvironments = Just ["staging", "production"]
+  Config.deployEnvironments = Just ["staging", "production"],
+  Config.deploySubprojects  = Nothing
 }
 
 -- Dummy user configuration used in test environment.


### PR DESCRIPTION
This PR adds the ability to specify specific subprojects to deploy. This makes it possible to write things like

merge and deploy foo
merge and deploy foo, bar
merge and deploy foo, bar to environment
merge and deploy foo, bar on friday
Merge commits will include an additional line Deploy-Subprojects: with a value of either all, or a comma-separated list of the subprojects to deploy.

CC: @Riscky, the PR for this has changed to this new one