### PR TITLE
Remember previously merged PRs for detecting pushes to master

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -259,7 +259,7 @@ projectThread config options metrics projectThreadData = do
           projectConfig
           (Config.mergeWindowExemption config)
           (Config.featureFreezeWindow config)
-          (Config.promotionTimeout config)
+          (Config.timeouts config)
           getNextEvent
           publish
           projectThreadState

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.33.1
+
+Release 2024-03-12
+
+  - Adds a list of recently promoted PRs to check if a push to master is one of these recently promoted PRs.
+
 ## 0.33.0
 
 Release 2024-01-13

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,6 +1,6 @@
 name:                hoff
 -- please keep version consistent with hoff.nix
-version:             0.33.0
+version:             0.33.1
 category:            Development
 synopsis:            A gatekeeper for your commits
 

--- a/hoff.nix
+++ b/hoff.nix
@@ -16,7 +16,7 @@ pkgs, mkDerivation
 , wai-middleware-prometheus, warp, warp-tls }:
 mkDerivation {
   pname = "hoff";
-  version = "0.33.0"; # please keep consistent with hoff.cabal
+  version = "0.33.1"; # please keep consistent with hoff.cabal
 
   src = let
     # We do not want to include all files, because that leads to a lot of things

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -35,5 +35,8 @@
     "start": "2023-01-01T00:00:00Z",
     "end": "2023-01-07T00:00:00Z"
   },
-  "promotionTimeout": 60
+  "timeouts": {
+    "promotionTimeout": 60,
+    "rememberTimeout": 600
+  }
 }

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -20,7 +20,7 @@ module Configuration
   MergeWindowExemptionConfiguration (..),
   MetricsConfiguration (..),
   FeatureFreezeWindow (..),
-  PromotionTimeout (..),
+  Timeouts (..),
   ClockTickInterval (..),
   loadConfiguration
 )
@@ -110,7 +110,11 @@ data MetricsConfiguration = MetricsConfiguration
 newtype MergeWindowExemptionConfiguration = MergeWindowExemptionConfiguration [Text]
   deriving (Generic, Show)
 
-newtype PromotionTimeout = PromotionTimeout DiffTime
+data Timeouts = Timeouts
+  {
+    promotionTimeout :: DiffTime,
+    rememberTimeout :: DiffTime
+  }
   deriving (Generic, Show)
 
 newtype ClockTickInterval = ClockTickInterval DiffTime
@@ -154,8 +158,8 @@ data Configuration = Configuration
     -- Feature freeze period in which only 'merge hotfix' commands are allowed
     featureFreezeWindow :: Maybe FeatureFreezeWindow,
 
-    -- The timeout for promoting an integrated pull request
-    promotionTimeout :: PromotionTimeout,
+    -- The timeouts for promoting an integrated pull request and remembering promoted pull requests
+    timeouts :: Timeouts,
 
     -- The interval to send clock tick events
     clockTickInterval :: Maybe ClockTickInterval
@@ -171,7 +175,7 @@ instance FromJSON UserConfiguration
 instance FromJSON MergeWindowExemptionConfiguration
 instance FromJSON MetricsConfiguration
 instance FromJSON FeatureFreezeWindow
-instance FromJSON PromotionTimeout
+instance FromJSON Timeouts
 instance FromJSON ClockTickInterval
 
 -- Reads and parses the configuration. Returns Nothing if parsing failed, but

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -222,8 +222,8 @@ mergeWindowExemptionConfig = MergeWindowExemptionConfiguration ["bot"]
 featureFreezeWindow :: Maybe FeatureFreezeWindow
 featureFreezeWindow = Nothing
 
-testPromotionTimeout :: Config.PromotionTimeout
-testPromotionTimeout = Config.PromotionTimeout 600
+testTimeouts :: Config.Timeouts
+testTimeouts = Config.Timeouts 600 600
 
 -- An interpreter for the GitHub API free monad that ignores most API calls, and
 -- provides fake inputs. We don't want to require a Github repository and API
@@ -284,7 +284,7 @@ runMainEventLoop projectConfig initialState events = do
         projectConfig
         mergeWindowExemptionConfig
         featureFreezeWindow
-        testPromotionTimeout
+        testTimeouts
         getNextEvent
         publish
         initialState


### PR DESCRIPTION
Adds an extra list to the state with recently merged PRs. When detecting a push to master we use this list to check if the push is from merging one of the known PRs.
