### PR TITLE
Attempt subprojects/environments by longest match first

### DIFF
--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -6,10 +6,12 @@ module Parser where
 import Control.Monad (void)
 import Data.Either (fromRight)
 import Data.List (intercalate, intersperse)
+import Data.Ord (Down(..))
 import Data.Text (Text)
 import Data.Void (Void)
 import Text.Megaparsec (ParseErrorBundle, Parsec, (<|>))
 
+import qualified Data.List as List
 import qualified Data.Text as Text
 import qualified Text.Megaparsec as P
 import qualified Text.Megaparsec.Char as P
@@ -135,15 +137,18 @@ parseMergeCommand projectConfig triggerConfig = cvtParseResult . P.parse pCommen
     commandPrefix :: Text
     commandPrefix = Text.strip $ commentPrefix triggerConfig
 
+    largestMatchFirst :: [Text] -> [Text]
+    largestMatchFirst = List.sortOn (Down . Text.length)
+
     -- No whitespace stripping or case folding is performed here to be
     -- consistent with how environments are handled.
     subprojects :: [Text]
-    subprojects = knownSubprojects projectConfig
+    subprojects = largestMatchFirst $ knownSubprojects projectConfig
 
     -- No whitespace stripping or case folding is performed here since they are
     -- also matched verbatim elsewhere in Hoff.
     environments :: [Text]
-    environments = knownEnvironments projectConfig
+    environments = largestMatchFirst $ knownEnvironments projectConfig
 
     -- The punctuation characters that are allowed at the end of a merge
     -- command. This doesn't use the included punctuation predicate because that

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1012,7 +1012,7 @@ main = hspec $ do
         ]
 
     it "rejects merge and deploy without an environment specified if multiple environments are configured"
-      $ expectSimpleParseFailure  "@bot merge and deploy" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:22:\n      |\n    1 | @bot merge and deploy\n      |                      ^\n    Merge and deploy has been deprecated. Please use merge and deploy to <environment>\n    where <environment> is one of staging, production\n"
+      $ expectSimpleParseFailure  "@bot merge and deploy" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:22:\n      |\n    1 | @bot merge and deploy\n      |                      ^\n    Merge and deploy has been deprecated. Please use merge and deploy to <environment>\n    where <environment> is one of production, staging\n"
 
     it "recognizes 'merge and deploy on Friday' commands as the proper ApprovedFor value" $ do
       let


### PR DESCRIPTION
When using `choice`, the first matching parser wins. This means if we are trying a list of strings, and one is a prefix of another, the longest string should be attempted first, or the smallest will always win.