### PR TITLE
Add `with priority` option to jump the merge train with high priority

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.34.0
+
+Release 2024-04-25
+
+  - Adds the option to jump the merge train. This can be done using `with priority` at the end of the merge command.
+  - Adds the merge priority to the merge commit message as `Priority: <priority>`.
+
 ## 0.33.2
 
 Release 2024-03-29

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,6 +1,6 @@
 name:                hoff
 -- please keep version consistent with hoff.nix
-version:             0.33.2
+version:             0.34.0
 category:            Development
 synopsis:            A gatekeeper for your commits
 

--- a/hoff.nix
+++ b/hoff.nix
@@ -16,7 +16,7 @@ pkgs, mkDerivation
 , wai-middleware-prometheus, warp, warp-tls }:
 mkDerivation {
   pname = "hoff";
-  version = "0.33.2"; # please keep consistent with hoff.cabal
+  version = "0.34.0"; # please keep consistent with hoff.cabal
 
   src = let
     # We do not want to include all files, because that leads to a lot of things

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -25,6 +25,7 @@ module Project
   Check (..),
   IntegrationStatus (..),
   OutstandingChecks (..),
+  Priority (..),
   ProjectInfo (..),
   ProjectState (..),
   PromotedPullRequest (..),
@@ -203,11 +204,15 @@ data Approval = Approval
   , approvedFor :: ApprovedFor
   , approvalOrder :: Int
   , approvalRetriedBy :: Maybe Username
+  , approvalPriority :: Priority
   }
   deriving (Eq, Show, Generic)
 
 data MergeWindow = OnFriday | DuringFeatureFreeze | AnyDay
   deriving (Eq, Show)
+
+data Priority = Normal | High
+  deriving (Eq, Show, Generic)
 
 -- | A check is a key we check incoming build status contexts (in the case of
 -- github) against.
@@ -287,6 +292,7 @@ instance FromJSON DeployEnvironment
 instance FromJSON DeploySubprojects
 instance FromJSON ApprovedFor
 instance FromJSON Approval
+instance FromJSON Priority
 instance FromJSON ProjectState
 instance FromJSON PullRequest
 
@@ -298,6 +304,7 @@ instance ToJSON DeployEnvironment where toEncoding = Aeson.genericToEncoding Aes
 instance ToJSON DeploySubprojects where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON ApprovedFor where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON Approval where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+instance ToJSON Priority where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON ProjectState where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON PullRequest where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 
@@ -667,8 +674,6 @@ isIntegratedOrSpeculativelyConflicted :: PullRequest -> Bool
 isIntegratedOrSpeculativelyConflicted pr =
   case integrationStatus pr of
   (Integrated _ _)                            -> True
-  (Promote _ _)                               -> True
-  (PromoteAndTag {})                          -> True
   (Conflicted base _) | base /= baseBranch pr -> True
   _                                           -> False
 

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -12,7 +12,7 @@ import qualified Test.QuickCheck as QC
 import Configuration (ProjectConfiguration (..), TriggerConfiguration (..))
 import Parser (ParseResult (..), parseMergeCommand)
 import Project (ApprovedFor (..), DeployEnvironment (..), DeploySubprojects (..),
-                MergeCommand (..), MergeWindow (..))
+                MergeCommand (..), MergeWindow (..), Priority (..))
 
 parserSpec :: Spec
 parserSpec = do
@@ -20,24 +20,32 @@ parserSpec = do
     describe "merge commands" $ do
       it "can parse 'merge'" $
         dummyParse "@bot merge" `shouldBe`
-          Success (Approve Merge, AnyDay)
+          Success (Approve Merge, AnyDay, Normal)
 
       it "can parse 'merge on friday'" $
         dummyParse "@bot merge on friday" `shouldBe`
-          Success (Approve Merge, OnFriday)
+          Success (Approve Merge, OnFriday, Normal)
 
       it "can parse 'merge as hotfix'" $
         dummyParse "@bot merge as hotfix" `shouldBe`
-          Success (Approve Merge, DuringFeatureFreeze)
+          Success (Approve Merge, DuringFeatureFreeze, Normal)
+
+      it "can parse 'with priority'" $
+        dummyParse "@bot merge with priority" `shouldBe`
+          Success (Approve Merge, AnyDay, High)
+
+      it "can parse 'with priority' on friday" $
+        dummyParse "@bot merge on friday with priority" `shouldBe`
+          Success (Approve Merge, OnFriday, High)
 
     describe "tag commands" $ do
       it "can parse 'merge and tag'" $
         dummyParse "@bot merge and tag" `shouldBe`
-          Success (Approve MergeAndTag, AnyDay)
+          Success (Approve MergeAndTag, AnyDay, Normal)
 
       it "can parse a merge window after 'tag'" $ do
         dummyParse "@bot merge and tag on friday" `shouldBe`
-          Success (Approve MergeAndTag, OnFriday)
+          Success (Approve MergeAndTag, OnFriday, Normal)
 
     describe "deploy commands" $ do
       let oneEnvProject = dummyProject { deployEnvironments = Just ["foo"] }
@@ -45,19 +53,23 @@ parserSpec = do
 
       it "selects the environment implicitly when there is only one" $
         oneEnvParse "@bot merge and deploy" `shouldBe`
-          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "foo"), AnyDay)
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "foo"), AnyDay, Normal)
 
       it "allows the environment to be specified when there is only one" $
         oneEnvParse "@bot merge and deploy to foo" `shouldBe`
-          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "foo"), AnyDay)
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "foo"), AnyDay, Normal)
 
       it "can parse a merge window after an implicit environment" $
         oneEnvParse "@bot merge and deploy as hotfix" `shouldBe`
-          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "foo"), DuringFeatureFreeze)
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "foo"), DuringFeatureFreeze, Normal)
+
+      it "can parse a priority after an implicit environment" $
+        oneEnvParse "@bot merge and deploy with priority" `shouldBe`
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "foo"), AnyDay, High)
 
       it "allows the environment to be specified when there are multiple" $
         dummyParse "@bot merge and deploy to staging" `shouldBe`
-          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "staging"), AnyDay)
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "staging"), AnyDay, Normal)
 
       it "fails when the environment is not specified and ambiguous" $
         dummyParse "@bot merge and deploy" `shouldBe`
@@ -77,15 +89,19 @@ parserSpec = do
 
       it "can parse a merge window after an explicit environment" $
         dummyParse "@bot merge and deploy to production on friday" `shouldBe`
-          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "production"), OnFriday)
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "production"), OnFriday, Normal)
+
+      it "can parse a priority after an explicit environment" $
+        dummyParse "@bot merge and deploy to production with priority" `shouldBe`
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "production"), AnyDay, High)
 
       it "allows a specific subproject to be deployed" $
         dummyParse "@bot merge and deploy aaa to production" `shouldBe`
-          Success (Approve $ MergeAndDeploy (OnlySubprojects ["aaa"]) (DeployEnvironment "production"), AnyDay)
+          Success (Approve $ MergeAndDeploy (OnlySubprojects ["aaa"]) (DeployEnvironment "production"), AnyDay, Normal)
 
       it "allows many specific subprojects to be deployed" $
         dummyParse "@bot merge and deploy aaa, bbb to production" `shouldBe`
-          Success (Approve $ MergeAndDeploy (OnlySubprojects ["aaa", "bbb"]) (DeployEnvironment "production"), AnyDay)
+          Success (Approve $ MergeAndDeploy (OnlySubprojects ["aaa", "bbb"]) (DeployEnvironment "production"), AnyDay, Normal)
 
       it "fails when an unknown subproject is specified" $
         dummyParse "@bot merge and deploy ccc to production" `shouldBe`
@@ -97,11 +113,11 @@ parserSpec = do
 
       it "allows subprojects to be specified with an implicit environment" $
         oneEnvParse "@bot merge and deploy aaa" `shouldBe`
-          Success (Approve $ MergeAndDeploy (OnlySubprojects ["aaa"]) (DeployEnvironment "foo"), AnyDay)
+          Success (Approve $ MergeAndDeploy (OnlySubprojects ["aaa"]) (DeployEnvironment "foo"), AnyDay, Normal)
 
       it "allows subprojects, an implicit environment, and a merge window" $
         oneEnvParse "@bot merge and deploy bbb on friday" `shouldBe`
-          Success (Approve $ MergeAndDeploy (OnlySubprojects ["bbb"]) (DeployEnvironment "foo"), OnFriday)
+          Success (Approve $ MergeAndDeploy (OnlySubprojects ["bbb"]) (DeployEnvironment "foo"), OnFriday, Normal)
 
       let prefixProject = dummyProject
                             { deployEnvironments = Just ["foo", "fooooooo"]
@@ -111,20 +127,20 @@ parserSpec = do
 
       it "allows environment names to be prefixes of each other" $
         prefixParse "@bot merge and deploy to fooooooo" `shouldBe`
-          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "fooooooo"), AnyDay)
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "fooooooo"), AnyDay, Normal)
 
       it "allows subproject names to be prefixes of each other" $
         prefixParse "@bot merge and deploy barrrrrr to fooooooo" `shouldBe`
-          Success (Approve $ MergeAndDeploy (OnlySubprojects ["barrrrrr"]) (DeployEnvironment "fooooooo"), AnyDay)
+          Success (Approve $ MergeAndDeploy (OnlySubprojects ["barrrrrr"]) (DeployEnvironment "fooooooo"), AnyDay, Normal)
 
     describe "retry commands" $ do
       it "can parse 'retry'" $
         dummyParse "@bot retry" `shouldBe`
-          Success (Retry, AnyDay)
+          Success (Retry, AnyDay, Normal)
 
       it "can parse a merge window after 'retry'" $
         dummyParse "@bot retry on friday" `shouldBe`
-          Success (Retry, OnFriday)
+          Success (Retry, OnFriday, Normal)
 
     describe "misc features" $ do
       it "ignores messages without the comment prefix" $
@@ -133,11 +149,11 @@ parserSpec = do
 
       it "accepts commands at the end of other comments" $
         dummyParse "LGTM, @bot merge" `shouldBe`
-          Success (Approve Merge, AnyDay)
+          Success (Approve Merge, AnyDay, Normal)
 
       it "accepts comments after a command if there is a newline" $
         dummyParse "@bot merge\nLGTM" `shouldBe`
-          Success (Approve Merge, AnyDay)
+          Success (Approve Merge, AnyDay, Normal)
 
       it "rejects following a command with another command" $
         dummyParse "@bot merge, @bot merge and tag" `shouldBe`
@@ -154,25 +170,25 @@ parserSpec = do
 
       it "parses case insensitively" $
         dummyParse "@bot MeRgE aNd TaG oN fRiDaY" `shouldBe`
-          Success (Approve MergeAndTag, OnFriday)
+          Success (Approve MergeAndTag, OnFriday, Normal)
 
       prop "allows trailing punctuation" $
         let genSuffix = Text.pack <$> QC.listOf (QC.elements ".,!?:;")
          in QC.forAll genSuffix $ \suffix ->
               dummyParse ("@bot merge" <> suffix) ==
-                Success (Approve Merge, AnyDay)
+                Success (Approve Merge, AnyDay, Normal)
 
       it "understands HTML comments" $
         dummyParse
           "@bot <!-- hi --> merge <!-- there --> and <!-- this --> deploy\
           \ <!-- is --> to <!-- a --> production <!-- secret --> on <!-- message --> friday"
           `shouldBe`
-          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "production"), OnFriday)
+          Success (Approve $ MergeAndDeploy EntireProject (DeployEnvironment "production"), OnFriday, Normal)
 
       -- Giving silly commands to the bot is a highly-valued feature ;)
       it "allows HTML comment chicanery" $
         dummyParse "<!--\n@bot merge\n--> @bot YEET" `shouldBe`
-          Success (Approve Merge, AnyDay)
+          Success (Approve Merge, AnyDay, Normal)
 
 {-
       TODO I would like to change the parser to be able to recognise the hoff
@@ -189,7 +205,7 @@ parserSpec = do
           Ignored
 -}
 
-dummyParse :: Text -> ParseResult (MergeCommand, MergeWindow)
+dummyParse :: Text -> ParseResult (MergeCommand, MergeWindow, Priority)
 dummyParse = parseMergeCommand dummyProject dummyTrigger
 
 dummyProject :: ProjectConfiguration


### PR DESCRIPTION
Adds the possibility to jump the merge train.
This can be done by adding `with priority` at the end of the merge command, for example like this:
`@bot merge and deploy to producton with priority`
This will put this PR at the front of the merge train and cancel the integration of the current PRs.
If it is a tag it will also add the priority to the tag description for further use.
Resolves #259 