### PR TITLE
Do not retry failed PRs in case of a high priority merge

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.34.1
+
+Release 2024-06-17
+
+  - Fixes an issue with retying failed PRs after a priority merge.
+
 ## 0.34.0
 
 Release 2024-04-25

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,6 +1,6 @@
 name:                hoff
 -- please keep version consistent with hoff.nix
-version:             0.34.0
+version:             0.34.1
 category:            Development
 synopsis:            A gatekeeper for your commits
 

--- a/hoff.nix
+++ b/hoff.nix
@@ -16,7 +16,7 @@ pkgs, mkDerivation
 , wai-middleware-prometheus, warp, warp-tls }:
 mkDerivation {
   pname = "hoff";
-  version = "0.34.0"; # please keep consistent with hoff.cabal
+  version = "0.34.1"; # please keep consistent with hoff.cabal
 
   src = let
     # We do not want to include all files, because that leads to a lot of things

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -75,6 +75,7 @@ module Project
   filterPullRequestsBy,
   approvedAfter,
   isIntegrated,
+  isFailedIntegrated,
   isUnfailedIntegrated,
   subMapByOwner,
   supersedes,


### PR DESCRIPTION
Changes the high priority logic to not retry failed PRs.
Resolves #263 
