### PR TITLE
Add a link to the readme when reporting parse errors

### DIFF
--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -689,9 +689,15 @@ handleCommentAdded triggerConfig mergeWindowExemption featureFreezeWindow prId a
           -- the oldschool four space markdown code blocks instead of fenced
           -- code blocks since it's less ambiguous.
           let monospaceMessage = Text.unlines . map ("    " <>) . Text.lines $ message
-              -- NOTE: This comment is added to prevent feedback loops, see
-              --       'shouldIgnoreComment'
-              fullComment = hoffIgnoreComment <> "Unknown or invalid command found:\n\n" <> monospaceMessage
+              usageLink = "https://github.com/channable/hoff/blob/master/readme.md#using-hoff"
+              usageInstructions = "[Basic usage is explained here.](" <> usageLink <> ")"
+              fullComment =
+                -- NOTE: This comment is added to prevent feedback loops, see
+                --       'shouldIgnoreComment'
+                hoffIgnoreComment
+                  <> "Unknown or invalid command found:\n\n"
+                  <> monospaceMessage
+                  <> usageInstructions
           () <- leaveComment prId fullComment
           pure state
         -- Cases where the parse was successful
@@ -732,7 +738,7 @@ doMerge projectConfig prId author state pr approvalType priority retriedBy = do
       High -> do
         let train = Pr.filterPullRequestsBy Pr.isIntegratedOrSpeculativelyConflicted state''
             setNewOrder newOrder pullRequest = pullRequest{
-              Pr.integrationStatus = NotIntegrated, 
+              Pr.integrationStatus = NotIntegrated,
               Pr.approval = (\x -> x{Pr.approvalOrder = newOrder}) <$> Pr.approval pullRequest
             }
             updatePullRequest (currState, started) pid =

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -955,7 +955,7 @@ main = hspec $ do
         results = defaultResults { resultIntegrate = [Right (Sha "def2345")] }
         (_, actions) = runActionCustomConfig (testProjectConfig{Config.deployEnvironments = Just []}) results $ handleEventTest event state
 
-      actions `shouldBe` [ALeaveComment prId "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:22:\n      |\n    1 | @bot merge and deploy\n      |                      ^\n    No deployment environments have been configured.\n"]
+      actions `shouldBe` [ALeaveComment prId "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:22:\n      |\n    1 | @bot merge and deploy\n      |                      ^\n    No deployment environments have been configured.\n[Basic usage is explained here.](https://github.com/channable/hoff/blob/master/readme.md#using-hoff)"]
 
     it "allows the 'merge and deploy on Friday' command when there is only one deployment environment configured " $ do
       let
@@ -1012,7 +1012,7 @@ main = hspec $ do
         ]
 
     it "rejects merge and deploy without an environment specified if multiple environments are configured"
-      $ expectSimpleParseFailure  "@bot merge and deploy" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:22:\n      |\n    1 | @bot merge and deploy\n      |                      ^\n    Merge and deploy has been deprecated. Please use merge and deploy to <environment>\n    where <environment> is one of production, staging\n"
+      $ expectSimpleParseFailure  "@bot merge and deploy" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:22:\n      |\n    1 | @bot merge and deploy\n      |                      ^\n    Merge and deploy has been deprecated. Please use merge and deploy to <environment>\n    where <environment> is one of production, staging\n[Basic usage is explained here.](https://github.com/channable/hoff/blob/master/readme.md#using-hoff)"
 
     it "recognizes 'merge and deploy on Friday' commands as the proper ApprovedFor value" $ do
       let
@@ -1204,7 +1204,7 @@ main = hspec $ do
         (\pr -> Project.approval pr == Just (Approval (Username "deckard") Project.Merge 0 Nothing Normal))
 
     it "notifies when command not recognized"
-      $ expectSimpleParseFailure  "@bot mergre" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:6:\n      |\n    1 | @bot mergre\n      |      ^^^^^\n    unexpected \"mergr\"\n    expecting \"merge\", \"retry\", or white space\n"
+      $ expectSimpleParseFailure  "@bot mergre" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:6:\n      |\n    1 | @bot mergre\n      |      ^^^^^\n    unexpected \"mergr\"\n    expecting \"merge\", \"retry\", or white space\n[Basic usage is explained here.](https://github.com/channable/hoff/blob/master/readme.md#using-hoff)"
 
     it "allow 'merge' on Friday for exempted users" $ do
       let
@@ -1534,7 +1534,7 @@ main = hspec $ do
     -- Previous versions of Hoff would still match the @merge and deploy@ part
     -- and deploy to the default environment instead
     it "rejects 'merge and deploy to prohno' with an error message"
-      $ expectSimpleParseFailure  "@bot merge and deploy to prohno" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:26:\n      |\n    1 | @bot merge and deploy to prohno\n      |                          ^^^^^^\n    unexpected \"prohno\"\n    expecting \"production\", \"staging\", or white space\n"
+      $ expectSimpleParseFailure  "@bot merge and deploy to prohno" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:26:\n      |\n    1 | @bot merge and deploy to prohno\n      |                          ^^^^^^\n    unexpected \"prohno\"\n    expecting \"production\", \"staging\", or white space\n[Basic usage is explained here.](https://github.com/channable/hoff/blob/master/readme.md#using-hoff)"
 
     it "allows merge commands followed by a period at the end of a sentence" $ do
       let
@@ -1563,7 +1563,7 @@ main = hspec $ do
     -- commands are added take freeform strings as their arguments (e.g. tag
     -- messages).
     it "rejects merge commands when it is followed by another sentence before a line break"
-      $ expectSimpleParseFailure  "@bot merge and deploy to staging. Done!" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:35:\n      |\n    1 | @bot merge and deploy to staging. Done!\n      |                                   ^\n    Merge commands may not be followed by anything other than a punctuation character ('.', ',', '!', '?', ':', ';').\n"
+      $ expectSimpleParseFailure  "@bot merge and deploy to staging. Done!" "<!-- Hoff: ignore -->\nUnknown or invalid command found:\n\n    comment:1:35:\n      |\n    1 | @bot merge and deploy to staging. Done!\n      |                                   ^\n    Merge commands may not be followed by anything other than a punctuation character ('.', ',', '!', '?', ':', ';').\n[Basic usage is explained here.](https://github.com/channable/hoff/blob/master/readme.md#using-hoff)"
 
     -- This is already implicitly checked in 'expectSimpleParseFailure', you can
     -- never be too sure


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

Resolves #261. I've decided to just add a (hard-coded) message linking to the syntax description in the readme; hard-coding a summarised description of the syntax might be nicer, but would essentially be duplication with the readme and risk getting out of sync. Ideally, the syntax description would be extracted from the parser, like what many CLI arg parsing libraries support, but that's not trivial, so leaving it to future work.
