### PR TITLE
Use reactions for confirmation when appropriate

### DIFF
--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -1,4 +1,16 @@
 { sources ? import ./sources.nix, pkgs }:
 self: super: {
   hoff = self.callPackage ../hoff.nix { };
+
+  github =
+    pkgs.haskell.lib.compose.appendPatches
+      [
+        # https://github.com/haskell-github/github/pull/509
+        (pkgs.fetchpatch {
+          name = "github.patch";
+          url = "https://github.com/haskell-github/github/commit/623105d3987c4bb4e67d48e5ae36a3af97480be9.patch";
+          sha256 = "sha256-3zRYnrxg9G+druD8o5iejCnTclxd2eg1V7BAO6USjzo=";
+        })
+      ]
+      super.github;
 }

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -71,7 +71,7 @@ eventFromCommentPayload payload =
   let number = PullRequestId payload.number
       author = payload.author -- TODO: Wrapper type
       body   = payload.body
-      commentAdded = Logic.CommentAdded number author body
+      commentAdded = Logic.CommentAdded number author payload.id body
   in case payload.action of
     Left Github.CommentCreated -> Just commentAdded
     Right Github.ReviewSubmitted -> Just commentAdded

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -111,7 +111,7 @@ import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 
-import Types (PullRequestId (..), Username)
+import Types (PullRequestId (..), Username, ReactableId)
 import Data.Time (UTCTime)
 
 -- For any integrated sha, we either wait for the first check, or for
@@ -202,6 +202,7 @@ data MergeCommand
 --   command, i.e. either just "merge" or "merge and deploy".
 data Approval = Approval
   { approver    :: Username
+  , approvalSource :: Maybe ReactableId
   , approvedFor :: ApprovedFor
   , approvalOrder :: Int
   , approvalRetriedBy :: Maybe Username

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -13,6 +13,8 @@ module Types
 (
   Body (..),
   PullRequestId (..),
+  CommentId (..),
+  ReactableId (..),
   Username (..),
 )
 where
@@ -20,7 +22,7 @@ where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.String (IsString)
 import Data.Text (Text)
-import Data.Text.Buildable (Buildable)
+import Data.Text.Buildable (Buildable(..))
 import GHC.Generics (Generic)
 
 import qualified Data.Aeson as Aeson
@@ -34,10 +36,35 @@ newtype PullRequestId = PullRequestId Int deriving (Eq, Ord, Show, Generic)
 -- The body of a pull request
 newtype Body = Body Text deriving (Eq, Show, Generic, IsString, Buildable)
 
+-- The numeric ID of an issue comment. (In GitHub's model, a PR is a special kind of issue.)
+newtype CommentId = CommentId Int
+  deriving (Eq, Ord, Show, Generic)
+
 instance FromJSON Body
 instance FromJSON PullRequestId
 instance FromJSON Username
+instance FromJSON CommentId
 
 instance ToJSON Body where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON PullRequestId where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
 instance ToJSON Username where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+instance ToJSON CommentId where toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+
+-- The numeric ID of something on GitHub we can react to.
+data ReactableId
+  = OnIssueComment CommentId
+  | OnPullRequest PullRequestId
+  -- Ideally we would also be able to react to PR reviews, but (as of 9-5-2024) there
+  -- doesn't seem to be a REST endpoint for that, despite it being possible through the UI.
+  deriving (Show, Eq, Ord, Generic)
+
+instance Buildable ReactableId where
+  build (OnIssueComment (CommentId commentId)) =
+    "issue comment " <> build commentId
+  build (OnPullRequest (PullRequestId prId)) =
+    "pull request " <> build prId
+
+instance FromJSON ReactableId
+
+instance ToJSON ReactableId where
+  toEncoding = Aeson.genericToEncoding Aeson.defaultOptions

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -232,6 +232,7 @@ testTimeouts = Config.Timeouts 600 600
 fakeRunGithub :: Eff (GithubApi.GithubOperation : es) a -> Eff es a
 fakeRunGithub = interpret $ \_ -> \case
   GithubApi.LeaveComment _pr _body -> pure ()
+  GithubApi.AddReaction _reactable _reaction -> pure ()
   GithubApi.HasPushAccess username -> pure $ username `elem` ["rachael", "deckard"]
   -- Pretend that these two GitHub API calls always fail in these tests.
   GithubApi.GetPullRequest _pr -> pure Nothing
@@ -433,7 +434,7 @@ eventLoopSpec = parallel $ do
         void $ runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Add Leon test results" "deckard" Nothing,
-            Logic.CommentAdded pr4 "rachael" "@bot merge",
+            Logic.CommentAdded pr4 "rachael" Nothing "@bot merge",
             Logic.BuildStatusChanged c4 "default" BuildSucceeded,
             Logic.PullRequestCommitChanged (PullRequestId 4) c4
           ]
@@ -495,7 +496,7 @@ eventLoopSpec = parallel $ do
         void $ runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Add Leon test results" "deckard" Nothing,
-            Logic.CommentAdded pr4 "rachael" "@bot merge",
+            Logic.CommentAdded pr4 "rachael" Nothing "@bot merge",
             Logic.BuildStatusChanged c4 "default" (BuildFailed Nothing)
           ]
       -- the build failed, so master's history is unchanged
@@ -523,7 +524,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr4 branch baseBranch c4 "Deploy tests!" "deckard" Nothing,
-            Logic.CommentAdded pr4 "rachael" "@bot merge and tag",
+            Logic.CommentAdded pr4 "rachael" Nothing "@bot merge and tag",
             Logic.BuildStatusChanged c4 "default" BuildSucceeded
           ]
 
@@ -583,7 +584,7 @@ eventLoopSpec = parallel $ do
         -- commit. A new tag `v2` should appear.
         state <- runLoop Project.emptyProjectState
           [ Logic.PullRequestOpened pr4 branch baseBranch c4 "Deploy tests!" "deckard" Nothing
-          , Logic.CommentAdded pr4 "rachael" "@bot merge and deploy to staging"
+          , Logic.CommentAdded pr4 "rachael" Nothing "@bot merge and deploy to staging"
           ]
 
         -- Extract the sha of the rebased commit from the project state.
@@ -642,7 +643,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr6 branch baseBranch c6 "Add Leon test results" "deckard" Nothing,
-            Logic.CommentAdded pr6 "rachael" "@bot merge"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge"
           ]
 
         -- Extract the sha of the rebased commit from the project state.
@@ -683,7 +684,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr6 branch baseBranch c6 "Deploy it now!" "deckard" Nothing,
-            Logic.CommentAdded pr6 "rachael" "@bot merge and tag"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge and tag"
           ]
 
         let [rebasedSha] = integrationShas state
@@ -742,7 +743,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr6 branch baseBranch c6 "Deploy it now!" "deckard" Nothing,
-            Logic.CommentAdded pr6 "rachael" "@bot merge and deploy to staging"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge and deploy to staging"
           ]
 
         let [rebasedSha] = integrationShas state
@@ -803,8 +804,8 @@ eventLoopSpec = parallel $ do
             Logic.PullRequestOpened pr6 br6 baseBranch c6 "Add Rachael test results" "deckard" Nothing,
             -- Note that although c4 has a lower pull request number, c6 should
             -- still be integrated first because it was approved earlier.
-            Logic.CommentAdded pr6 "rachael" "@bot merge",
-            Logic.CommentAdded pr4 "rachael" "@bot merge"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge",
+            Logic.CommentAdded pr4 "rachael" Nothing "@bot merge"
           ]
 
         -- Extract the sha of the rebased commit from the project state.
@@ -847,8 +848,8 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr4 br4 baseBranch c4 "Add Leon test results" "deckard" Nothing,
             Logic.PullRequestOpened pr6 br6 baseBranch c6 "Add Rachael test results" "deckard" Nothing,
-            Logic.CommentAdded pr6 "rachael" "@bot merge and tag",
-            Logic.CommentAdded pr4 "rachael" "@bot merge and tag"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge and tag",
+            Logic.CommentAdded pr4 "rachael" Nothing "@bot merge and tag"
           ]
 
         let [rebasedSha,_] = integrationShas state
@@ -930,8 +931,8 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr3 br3 baseBranch c3' "Add Leon test results" "deckard" Nothing,
             Logic.PullRequestOpened pr4 br4 baseBranch c4 "Add Rachael test results" "deckard" Nothing,
-            Logic.CommentAdded pr3 "rachael" "@bot merge",
-            Logic.CommentAdded pr4 "rachael" "@bot merge"
+            Logic.CommentAdded pr3 "rachael" Nothing "@bot merge",
+            Logic.CommentAdded pr4 "rachael" Nothing "@bot merge"
           ]
 
         -- The first pull request should be marked as conflicted. Note: this
@@ -971,7 +972,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr6 branch baseBranch c6 "Add test results" "deckard" Nothing,
-            Logic.CommentAdded pr6 "rachael" "@bot merge"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge"
           ]
 
         -- At this point, c6 has been rebased and pushed to the "integration"
@@ -1026,7 +1027,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr6 branch baseBranch c6 "Add test results" "deckard" Nothing,
-            Logic.CommentAdded pr6 "rachael" "@bot merge and tag"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge and tag"
           ]
 
         -- At this point, c6 has been rebased and pushed to the "integration"
@@ -1099,7 +1100,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr6 branch baseBranch c6 "Add test results" "deckard" Nothing,
-            Logic.CommentAdded pr6 "rachael" "@bot merge and tag"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge and tag"
           ]
 
         -- At this point, c6 has been rebased and pushed to the "integration" branch for building.
@@ -1176,7 +1177,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr8 branch baseBranch c7f "Add test results" "deckard" Nothing,
-            Logic.CommentAdded pr8 "rachael" "@bot merge"
+            Logic.CommentAdded pr8 "rachael" Nothing "@bot merge"
           ]
 
         -- Extract the sha of the rebased commit from the project state, and
@@ -1214,7 +1215,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr8 branch baseBranch c7f "Add test results" "deckard" Nothing,
-            Logic.CommentAdded pr8 "rachael" "@bot merge"
+            Logic.CommentAdded pr8 "rachael" Nothing "@bot merge"
           ]
 
         git ["fetch", "origin", "ahead"] -- The ref for commit c4.
@@ -1268,7 +1269,7 @@ eventLoopSpec = parallel $ do
         state <- runLoop Project.emptyProjectState
           [
             Logic.PullRequestOpened pr8 branch baseBranch c7f "Add test results" "deckard" Nothing,
-            Logic.CommentAdded pr8 "rachael" "@bot merge"
+            Logic.CommentAdded pr8 "rachael" Nothing "@bot merge"
           ]
 
         -- Extract the sha of the rebased commit from the project state, and
@@ -1306,7 +1307,7 @@ eventLoopSpec = parallel $ do
           [
             Logic.PullRequestOpened pr6 branch6 baseBranch c6 "Add Leon test results" "deckard" Nothing,
             Logic.PullRequestOpened pr8 branch8 baseBranch c7f "Update Leon data" "deckard" Nothing,
-            Logic.CommentAdded pr8 "rachael" "@bot merge"
+            Logic.CommentAdded pr8 "rachael" Nothing "@bot merge"
           ]
 
         Project.unfailedIntegratedPullRequests state `shouldBe` [pr8]
@@ -1319,7 +1320,7 @@ eventLoopSpec = parallel $ do
           [
             Logic.BuildStatusChanged rebasedSha "default" BuildSucceeded,
             Logic.PullRequestCommitChanged (PullRequestId 8) rebasedSha,
-            Logic.CommentAdded pr6 "rachael" "@bot merge"
+            Logic.CommentAdded pr6 "rachael" Nothing "@bot merge"
           ]
 
         Project.unfailedIntegratedPullRequests state' `shouldBe` []


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

Closes #198. This ended up being more work than you'd expect, and due to a seeming omission from GitHub's API, we can't send a reaction in *every* case, in which case we fall back to an old-fashioned comments. I also decided to fall back to posting a comment if the PR isn't immediately at the top of the merge queue, but maybe there's no need to be that informative.

Depends on https://github.com/haskell-github/github/pull/509 to be able to use the Reactions API. I've added that as a patch to the Nix overlay; if there's contributors that want to work without Nix then it should be doable to get that patch by adding to `cabal.project` as well.
