### PR TITLE
Upgrade Semaphore CI image to 22.04

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,7 +5,7 @@ name: "Hoff"
 agent:
   machine:
     type: "f1-standard-2"
-    os_image: "ubuntu2004"
+    os_image: "ubuntu2204"
 
 # If we push a new build to some branch that isn't master, and another build is
 # already running, we cancel it.


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

## Description


Upgrades Semaphore CI image from 20.04 to 22.04