### PR TITLE
enable deploying on Fridays

### DIFF
--- a/doc/example-dev-config.json
+++ b/doc/example-dev-config.json
@@ -16,7 +16,8 @@
     "deploySubprojects": [
       "staging",
       "production"
-    ]
+    ],
+    "safeForFriday": true
   }],
   "secret": "REPLACE with output of 'head --bytes 32 /dev/urandom | base64'",
   "accessToken": "REPLACE with a new personal access token from https://github.com/settings/tokens",

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -17,6 +17,26 @@
       "staging",
       "production"
     ]
+  },
+  {
+    "owner": "your-github-username-or-organization",
+    "repository": "your-repo",
+    "branch": "master",
+    "testBranch": "testing",
+    "checkout": "/var/lib/hoff/checkouts/your-username/your-repo",
+    "stateFile": "/var/lib/hoff/state/your-username/your-repo.json",
+    "checks": {
+      "mandatory": []
+    },
+    "deployEnvironments": [
+      "staging",
+      "production"
+    ],
+    "deploySubprojects": [
+      "staging",
+      "production"
+    ],
+    "safeForFriday": true
   }],
   "secret": "run 'head --bytes 32 /dev/urandom | base64' and paste output here",
   "accessToken": "paste a personal access token for a bot user here",

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -46,7 +46,8 @@ data ProjectConfiguration = ProjectConfiguration
     stateFile          :: FilePath,                  -- The file where project state is stored.
     checks             :: Maybe ChecksConfiguration, -- Optional configuration related to checks for the project.
     deployEnvironments :: Maybe [Text],              -- The environments which the `deploy to <environment>` command should be enabled for
-    deploySubprojects  :: Maybe [Text]               -- The subprojects which the `deploy` command should be enabled for
+    deploySubprojects  :: Maybe [Text],              -- The subprojects which the `deploy` command should be enabled for
+    safeForFriday      :: Maybe Bool                 -- Whether it's safe to deploy this project on Friday without an "on Friday" check. default False
   }
   deriving (Generic)
 

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -63,7 +63,7 @@ import qualified Data.Text.Lazy.Builder.Int as B
 import qualified Data.Text.Read as Text
 import Data.Time (UTCTime, DayOfWeek (Friday), dayOfWeek, utctDay)
 
-import Configuration (ProjectConfiguration (owner, repository), TriggerConfiguration, MergeWindowExemptionConfiguration, FeatureFreezeWindow, Timeouts)
+import Configuration (ProjectConfiguration (owner, repository, safeForFriday), TriggerConfiguration, MergeWindowExemptionConfiguration, FeatureFreezeWindow, Timeouts)
 import Effectful (Dispatch (Dynamic), DispatchOf, Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpret, send)
 import Format (format)
@@ -679,7 +679,7 @@ handleCommentAdded triggerConfig mergeWindowExemption featureFreezeWindow prId a
                                           \we are in a feature-freeze period. Run '" <>
                                           Pr.displayMergeCommand command <> " as hotfix' instead.")
                 pure state
-            | day == Friday = do
+            | day == Friday && safeForFriday projectConfig /= Just True  = do
                 () <- leaveComment prId ("Your merge request has been denied, because \
                                           \merging on Fridays is not recommended. \
                                           \To override this behaviour use the command `"

--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -205,7 +205,8 @@ buildProjectConfig repoDir stateFile = Config.ProjectConfiguration {
   Config.stateFile          = stateFile,
   Config.checks             = Just (Config.ChecksConfiguration Set.empty),
   Config.deployEnvironments = Just ["staging", "production"],
-  Config.deploySubprojects  = Nothing
+  Config.deploySubprojects  = Nothing,
+  Config.safeForFriday      = Nothing
 }
 
 -- Dummy user configuration used in test environment.

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -220,6 +220,7 @@ dummyProject =
     , checks              = Nothing
     , deployEnvironments  = Just ["production", "staging"]
     , deploySubprojects   = Just ["aaa", "bbb"]
+    , safeForFriday       = Just True
     }
 
 dummyTrigger :: TriggerConfiguration


### PR DESCRIPTION
Adds a per project configuration.

A new optional JSON field is created with this PR. If `rootObj.projects[].safeForFriday` is set to `true`, then the project can be deployed on Fridays without needing to add `on Friday` to comments to the bot.

EDIT: This PR addresses #267 

<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->
