### PR TITLE
haskell-overlay.nix: Switch `github` to latest Hackage version

### DIFF
--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -89,7 +89,7 @@ constraints: any.HUnit ==1.6.2.0,
              any.ghc-bignum ==1.3,
              any.ghc-boot-th ==9.6.5,
              any.ghc-prim ==0.10.0,
-             any.github ==0.29,
+             any.github ==0.30,
              any.hashable ==1.4.4.0,
              any.haskell-lexer ==1.1.1,
              any.hourglass ==0.2.12,
@@ -210,4 +210,4 @@ constraints: any.HUnit ==1.6.2.0,
              any.witherable ==0.4.2,
              any.word8 ==0.1.3,
              any.zlib ==0.6.3.0
-index-state: hackage.haskell.org 2024-04-26T10:39:31Z
+index-state: hackage.haskell.org 2025-05-15T07:59:00Z

--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -2,15 +2,15 @@
 self: super: {
   hoff = self.callPackage ../hoff.nix { };
 
+  # This version isn't in our nixpkgs yet, but we need it because it adds
+  # support for reactions endpoints.
   github =
-    pkgs.haskell.lib.compose.appendPatches
-      [
-        # https://github.com/haskell-github/github/pull/509
-        (pkgs.fetchpatch {
-          name = "github.patch";
-          url = "https://github.com/haskell-github/github/commit/623105d3987c4bb4e67d48e5ae36a3af97480be9.patch";
-          sha256 = "sha256-3zRYnrxg9G+druD8o5iejCnTclxd2eg1V7BAO6USjzo=";
-        })
-      ]
-      super.github;
+    pkgs.haskell.lib.overrideCabal super.github {
+      version = "0.30";
+      sha256 = "sha256-Lq4kOOcZIIBFXW8XNhak4HfryyBjB54Ewks4/fNrPBM=";
+      # Since the version in nixpkgs uses a revision, we need to explicitly
+      # unset it (and the corresponding `.cabal` file hash).
+      revision = null;
+      editedCabalFile = null;
+    };
 }


### PR DESCRIPTION
<!-- NOTE:
Keep in mind that this repository is public. Please avoid posting things like
logs with references to private repositories.
-->

https://github.com/haskell-github/github/pull/509 was merged and is released. Once it's in our nixpkgs version then we can remove the override entirely.